### PR TITLE
fix: spec consistency and correctness fixes

### DIFF
--- a/conformance/examples/registry-server.py
+++ b/conformance/examples/registry-server.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """
 Mock Agent Registry REST API Server
-Implements standard v0.9 Agentic Resource Discovery REST endpoints:
+Implements standard v0.4 Agentic Resource Discovery REST endpoints:
   - POST /search
-  - POST /explore
   - GET /agents
 Zero dependencies, uses Python standard library.
 """

--- a/conformance/examples/registry-server.py
+++ b/conformance/examples/registry-server.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
 Mock Agent Registry REST API Server
-Implements standard v0.4 Agentic Resource Discovery REST endpoints:
+Implements standard v0.9 Agentic Resource Discovery REST endpoints:
   - POST /search
+  - POST /explore
   - GET /agents
 Zero dependencies, uses Python standard library.
 """

--- a/spec/ard.md
+++ b/spec/ard.md
@@ -164,7 +164,7 @@ Each object in the entries array MUST contain:
 
 | Field | Type | Description |
 | :---- | :---- | :---- |
-| identifier | String | Globally unique logical identifier for discovery. MUST use a domain-anchored URN namespace format (`urn:ai:<publisher>:<namespace>:<agent-name>`) where <publisher> is a verifiable domain name and <namespace> is optional (see §4.2.1). This guarantees cross-network uniqueness, nomenclature stability, and decentralized trust binding. See [§4.2.1](#421-agent-identifier-identifier-format-and-rationale) for detailed format specifications and architectural rationale. |
+| identifier | String | Globally unique logical identifier for discovery. MUST use a domain-anchored URN namespace format (`urn:ai:<publisher>:<namespace>:<agent-name>`) where <publisher> is a verifiable domain name. This guarantees cross-network uniqueness, nomenclature stability, and decentralized trust binding. See [§4.2.1](#421-agent-identifier-identifier-format-and-rationale) for detailed format specifications and architectural rationale. |
 | displayName | String | Human-readable name. |
 | type | String | Type of the AI artifact. |
 

--- a/spec/ard.md
+++ b/spec/ard.md
@@ -638,13 +638,13 @@ This gives the client full control over the federation topology without requirin
     {
       "identifier": "urn:air:nlweb.ai:registry:public",
       "displayName": "Public Agent Finder",
-      "type": "application/ai-registry+json",
+      "type": "application/ai-registry",
       "url": "https://finder.nlweb.ai/search"
     },
     {
       "identifier": "urn:air:example.com:registry:travel",
       "displayName": "Travel Agent Finder",
-      "type": "application/ai-registry+json",
+      "type": "application/ai-registry",
       "url": "https://travel.finder.example/search"
     }
   ]

--- a/spec/ard.md
+++ b/spec/ard.md
@@ -164,7 +164,7 @@ Each object in the entries array MUST contain:
 
 | Field | Type | Description |
 | :---- | :---- | :---- |
-| identifier | String | Globally unique logical identifier for discovery. MUST use a domain-anchored URN namespace format (`urn:ai:<publisher>[:<namespace>]:<name>`) where <publisher> is a verifiable domain name. This guarantees cross-network uniqueness, nomenclature stability, and decentralized trust binding. See [§4.2.1](#421-agent-identifier-identifier-format-and-rationale) for detailed format specifications and architectural rationale. |
+| identifier | String | Globally unique logical identifier for discovery. MUST use a domain-anchored URN namespace format (`urn:ai:<publisher>:<namespace>:<agent-name>`) where <publisher> is a verifiable domain name and <namespace> is optional (see §4.2.1). This guarantees cross-network uniqueness, nomenclature stability, and decentralized trust binding. See [§4.2.1](#421-agent-identifier-identifier-format-and-rationale) for detailed format specifications and architectural rationale. |
 | displayName | String | Human-readable name. |
 | type | String | Type of the AI artifact. |
 

--- a/spec/ard.md
+++ b/spec/ard.md
@@ -42,7 +42,7 @@ Traditional tool selection relies on injecting all descriptions into the LLM's c
 
 The specification does not define or constrain the internal schema of specific agent types (MCP, A2A, etc.). Instead, it acts as a clean envelope that uses a `type` field (formatted as an IANA Media Type) to identify what an artifact is, delegating the definition of artifact-specific metadata to the respective protocol specifications.
 
-\[\!NOTE\] **IANA Registration Status**: The types application/a2a-agent-card+json and application/mcp-server+json used in this specification are de-facto community standards tracking towards formal registration. Implementers should note that while well-known path directories (like /.well-known/agent-card.json) are officially registered permanent entries, full type registrations are pending working group joint submission and the format may change. In the meantime, omit strict verification of these types by intermediaries.
+\[\!NOTE\] **IANA Registration Status**: The types application/a2a-agent-card+json and application/mcp-server-card+json used in this specification are de-facto community standards tracking towards formal registration. Implementers should note that while well-known path directories (like /.well-known/agent-card.json) are officially registered permanent entries, full type registrations are pending working group joint submission and the format may change. In the meantime, omit strict verification of these types by intermediaries.
 
 ### 3.4 Strict Value-or-Reference
 
@@ -92,7 +92,7 @@ A manifest file hosted at /.well-known/ai-catalog.json lists the available artif
     {
       "identifier": "urn:ai:acme.com:server:weather",
       "displayName": "Weather Data Node",
-      "type": "application/mcp-server+json",
+      "type": "application/mcp-server-card+json",
       "url": "https://api.acme.com/mcp/weather.json",
       "capabilities": ["WeatherTool", "ForecastTool"],
       "description": "Enterprise weather MCP server for live telemetry.",
@@ -164,7 +164,7 @@ Each object in the entries array MUST contain:
 
 | Field | Type | Description |
 | :---- | :---- | :---- |
-| identifier | String | Globally unique logical identifier for discovery. MUST use a domain-anchored URN namespace format (`urn:ai:<publisher>:<namespace>:<agent-name>`) where <publisher> is a verifiable domain name. This guarantees cross-network uniqueness, nomenclature stability, and decentralized trust binding. See [§4.2.1](#421-agent-identifier-identifier-format-and-rationale) for detailed format specifications and architectural rationale. |
+| identifier | String | Globally unique logical identifier for discovery. MUST use a domain-anchored URN namespace format (`urn:ai:<publisher>[:<namespace>]:<name>`) where <publisher> is a verifiable domain name. This guarantees cross-network uniqueness, nomenclature stability, and decentralized trust binding. See [§4.2.1](#421-agent-identifier-identifier-format-and-rationale) for detailed format specifications and architectural rationale. |
 | displayName | String | Human-readable name. |
 | type | String | Type of the AI artifact. |
 
@@ -234,8 +234,8 @@ An agent hosted on Hugging Face Spaces (MCP), published in a manifest:
     {
       "identifier": "urn:ai:hf.co:alice-dev:weather-agent",
       "displayName": "Weather Agent",
-      "type": "application/mcp-server+json",
-      "inline": {
+      "type": "application/mcp-server-card+json",
+      "data": {
         "name": "Weather Agent",
         "description": "Simple weather lookup using open data",
         "tools": [
@@ -283,7 +283,7 @@ Discovery via GitHub Pages (combining the above):
     {
       "identifier": "urn:ai:hf.co:alice-dev:weather-agent",
       "displayName": "Weather Agent",
-      "type": "application/mcp-server+json",
+      "type": "application/mcp-server-card+json",
       "url": "https://alice-dev.github.io/weather-agent/entry.json"
     },
     {
@@ -483,7 +483,7 @@ The response returns standard catalog entries with additional relevance scores, 
     {
       "identifier": "urn:ai:example.com:weather-server",
       "displayName": "Global Weather Service",
-      "type": "application/mcp-server+json",
+      "type": "application/mcp-server-card+json",
       "url": "https://weather.example.com/mcp",
       "capabilities": ["WeatherTool"],
       "score": 88,
@@ -494,7 +494,7 @@ The response returns standard catalog entries with additional relevance scores, 
     {
       "identifier": "urn:ai:nlweb.ai:registry:public",
       "displayName": "Public Agent Finder",
-      "type": "application/ai-registry",
+      "type": "application/ai-registry+json",
       "url": "https://finder.nlweb.ai/search"
     }
   ],
@@ -558,7 +558,7 @@ Each element of `resultType.facets`:
   "facets": {
     "type": {
       "buckets": [
-        { "value": "application/mcp-server+json", "count": 1247 },
+        { "value": "application/mcp-server-card+json", "count": 1247 },
         { "value": "application/a2a-agent-card+json", "count": 389 }
       ],
       "otherCount": 23
@@ -591,7 +591,7 @@ Deterministic browsing, designed for developer portals. Highly cacheable, relies
 | pageSize | Integer | Max results (default: 20, max: 100). |
 | pageToken | String | Pagination token. |
 
-### 7.3 Protocol Wrappers (Optional)
+### 7.5 Protocol Wrappers (Optional)
 
 While the REST API is mandated as the floor for interoperability, a Registry **MAY** additionally expose its search capability natively via an MCP Tool or an A2A Skill to preserve native orchestrator flows.
 
@@ -636,15 +636,15 @@ This gives the client full control over the federation topology without requirin
   ],
   "referrals": [
     {
-      "identifier": "urn:ai:blweb.ai:registry:public",
+      "identifier": "urn:ai:nlweb.ai:registry:public",
       "displayName": "Public Agent Finder",
-      "type": "application/ai-registry",
+      "type": "application/ai-registry+json",
       "url": "https://finder.nlweb.ai/search"
     },
     {
       "identifier": "urn:ai:example.com:registry:travel",
       "displayName": "Travel Agent Finder",
-      "type": "application/ai-registry",
+      "type": "application/ai-registry+json",
       "url": "https://travel.finder.example/search"
     }
   ]
@@ -664,7 +664,7 @@ A user asks an orchestrator: “Book me a flight to Tokyo and file the travel ex
 
 ## Appendix A: Filter Expression Syntax
 
-The filter parameter in the Search API uses a simple EBNF-like format for structured constraints.
+The filter parameter in the List API (GET /agents) uses a simple EBNF-like format for structured constraints.
 
 | Filter Field | Type | Description |
 | :---- | :---- | :---- |
@@ -730,7 +730,7 @@ npx ajv-cli validate -s spec/schemas/ai-catalog.schema.json -d path/to/ai-catalo
 
 ### D.3 The Registry REST API Specification (OpenAPI)
 
-The HTTP query interfaces (`POST /search` and `GET /agents`) exposed by compliant Agent Registries are formally defined using the **OpenAPI 3.1.0 Specification** in YAML.
+The HTTP query interfaces (`POST /search`, `POST /explore`, and `GET /agents`) exposed by compliant Agent Registries are formally defined using the **OpenAPI 3.1.0 Specification** in YAML.
 
 * **Authoritative Specification File**: [`spec/schemas/ard.openapi.yaml`](schemas/ard.openapi.yaml)
 * **Key Integration Benefits**:

--- a/spec/schemas/ai-catalog.schema.json
+++ b/spec/schemas/ai-catalog.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/Agent-Card/agentfinder/main/spec/schemas/ai-catalog.schema.json",
+  "$id": "https://raw.githubusercontent.com/ards-project/ard-spec/main/spec/schemas/ai-catalog.schema.json",
   "title": "AICatalogManifest",
   "description": "JSON Schema for the ai-catalog.json capability manifest, defining how AI artifacts are advertised.",
   "type": "object",


### PR DESCRIPTION
Aligns spec examples and prose with the schemas, ADRs, and each other. No normative changes — just fixing places where examples or descriptions fell out of sync.

### Changes

**Example fixes:**
- `"inline"` → `"data"` in Solo-Dev example (§4.4) — `inline` is not a defined key; §3.4 specifies `url` or `data`
- `blweb.ai` → `nlweb.ai` typo in Federation URN (§8) — URL in the same object points to `finder.nlweb.ai`

**Media type alignment (per ADR-0008):**
- `application/mcp-server+json` → `application/mcp-server-card+json` in 6 places — schemas and conformance tests already use the new name
- `application/ai-registry` → `application/ai-registry+json` in 3 referral examples — matches §4.1 and §7 prose

**Section numbering:**
- Renumbered duplicate §7.3 ("Protocol Wrappers") to §7.5 — it follows §7.4 ("List")

**Appendix corrections:**
- Appendix A: "Search API" → "List API (GET /agents)" — EBNF filters apply to the List endpoint, not POST /search (per ADR-0004)
- Appendix D.3: added `POST /explore` to endpoint list — the OpenAPI file already defines it

**Schema housekeeping:**
- Updated JSON Schema `$id` from `Agent-Card/agentfinder` to `ards-project/ard-spec`