### PR TITLE
feat(trust): add TRACE-v0.2 runtime governance attestation type

### DIFF
--- a/conformance/examples/agentrust-io-catalog.json
+++ b/conformance/examples/agentrust-io-catalog.json
@@ -1,5 +1,4 @@
 {
-  "$comment": "Reference: agentrust.io governed-agent catalog. All entries carry TRACE-v0.2 runtime governance attestations alongside SPIFFE X.509 identity.",
   "specVersion": "1.0",
   "host": {
     "displayName": "agentrust.io",
@@ -12,7 +11,8 @@
       "attestations": [
         {
           "type": "SPIFFE-X509",
-          "uri": "https://agentrust.io/.well-known/spiffe/jwks"
+          "uri": "https://agentrust.io/.well-known/spiffe/jwks",
+          "mediaType": "application/jwk-set+json"
         }
       ]
     }
@@ -33,11 +33,13 @@
         "attestations": [
           {
             "type": "SPIFFE-X509",
-            "uri": "https://agentrust.io/.well-known/spiffe/jwks"
+            "uri": "https://agentrust.io/.well-known/spiffe/jwks",
+            "mediaType": "application/jwk-set+json"
           },
           {
             "type": "TRACE-v0.2",
             "uri": "https://trace.agentrust.io/records/cmcp-prod-latest",
+            "mediaType": "application/json",
             "digest": "sha256:3f4a8b2c1d9e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2"
           }
         ]
@@ -46,7 +48,7 @@
     {
       "identifier": "urn:air:agentrust.io:governed:agent-manifest",
       "displayName": "Agent Manifest SDK",
-      "description": "Hardware-anchors all 10 artifacts defining an agent at deployment. Attestation extended to agents — attested at registration and re-attested on any change.",
+      "description": "Hardware-anchors all 10 artifacts defining an agent at deployment. Agents are attested at registration and re-attested on any change.",
       "type": "application/mcp-server+json",
       "url": "https://api.agentrust.io/mcp/agent-manifest",
       "version": "0.1.0",
@@ -58,11 +60,13 @@
         "attestations": [
           {
             "type": "SPIFFE-X509",
-            "uri": "https://agentrust.io/.well-known/spiffe/jwks"
+            "uri": "https://agentrust.io/.well-known/spiffe/jwks",
+            "mediaType": "application/jwk-set+json"
           },
           {
             "type": "TRACE-v0.2",
             "uri": "https://trace.agentrust.io/records/agent-manifest-prod-latest",
+            "mediaType": "application/json",
             "digest": "sha256:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"
           }
         ]
@@ -83,11 +87,13 @@
         "attestations": [
           {
             "type": "SPIFFE-X509",
-            "uri": "https://agentrust.io/.well-known/spiffe/jwks"
+            "uri": "https://agentrust.io/.well-known/spiffe/jwks",
+            "mediaType": "application/jwk-set+json"
           },
           {
             "type": "TRACE-v0.2",
             "uri": "https://trace.agentrust.io/records/trace-registry-prod-latest",
+            "mediaType": "application/json",
             "digest": "sha256:f0e9d8c7b6a5f4e3d2c1b0a9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c3b2a1f0e9"
           }
         ]

--- a/conformance/examples/agentrust-io-catalog.json
+++ b/conformance/examples/agentrust-io-catalog.json
@@ -19,7 +19,7 @@
   },
   "entries": [
     {
-      "identifier": "urn:ai:agentrust.io:governed:cmcp-gateway",
+      "identifier": "urn:air:agentrust.io:governed:cmcp-gateway",
       "displayName": "Confidential MCP Gateway (cMCP)",
       "description": "Hardware-attested policy enforcement gateway for MCP tool calls. Cedar policies evaluated inside AMD SEV-SNP / Intel TDX TEE. Every session produces a TRACE Trust Record independently verifiable offline.",
       "type": "application/mcp-server+json",
@@ -44,7 +44,7 @@
       }
     },
     {
-      "identifier": "urn:ai:agentrust.io:governed:agent-manifest",
+      "identifier": "urn:air:agentrust.io:governed:agent-manifest",
       "displayName": "Agent Manifest SDK",
       "description": "Hardware-anchors all 10 artifacts defining an agent at deployment. Attestation extended to agents — attested at registration and re-attested on any change.",
       "type": "application/mcp-server+json",
@@ -69,7 +69,7 @@
       }
     },
     {
-      "identifier": "urn:ai:agentrust.io:governed:trace-registry",
+      "identifier": "urn:air:agentrust.io:governed:trace-registry",
       "displayName": "TRACE Registry",
       "description": "Public append-only Merkle registry for TRACE Trust Record anchors. Query attested session records for any TRACE-governed agent. Supports SCITT-anchored verification.",
       "type": "application/mcp-server+json",
@@ -94,7 +94,7 @@
       }
     },
     {
-      "identifier": "urn:ai:agentrust.io:registry:governed-agents",
+      "identifier": "urn:air:agentrust.io:registry:governed-agents",
       "displayName": "agentrust.io Governed Agent Registry",
       "description": "Federated ARD registry for TRACE-attested, policy-governed agents. All indexed entries carry TRACE-v0.2 runtime governance attestations. Filter with trustManifest.attestations.type=[TRACE-v0.2] to find governed agents across the federation.",
       "type": "application/ai-registry+json",

--- a/examples/agentrust-io-catalog.json
+++ b/examples/agentrust-io-catalog.json
@@ -1,0 +1,105 @@
+{
+  "$comment": "Reference: agentrust.io governed-agent catalog. All entries carry TRACE-v0.2 runtime governance attestations alongside SPIFFE X.509 identity.",
+  "specVersion": "1.0",
+  "host": {
+    "displayName": "agentrust.io",
+    "identifier": "agentrust.io",
+    "documentationUrl": "https://agentrust.io/docs",
+    "logoUrl": "https://agentrust.io/assets/logo.svg",
+    "trustManifest": {
+      "identity": "spiffe://trust.agentrust.io/registry/global",
+      "identityType": "spiffe",
+      "attestations": [
+        {
+          "type": "SPIFFE-X509",
+          "uri": "https://agentrust.io/.well-known/spiffe/jwks"
+        }
+      ]
+    }
+  },
+  "entries": [
+    {
+      "identifier": "urn:ai:agentrust.io:governed:cmcp-gateway",
+      "displayName": "Confidential MCP Gateway (cMCP)",
+      "description": "Hardware-attested policy enforcement gateway for MCP tool calls. Cedar policies evaluated inside AMD SEV-SNP / Intel TDX TEE. Every session produces a TRACE Trust Record independently verifiable offline.",
+      "type": "application/mcp-server+json",
+      "url": "https://api.agentrust.io/mcp/cmcp",
+      "version": "0.2.0",
+      "tags": ["governance", "confidential-computing", "policy-enforcement", "mcp", "tee"],
+      "capabilities": ["PolicyEnforcement", "HardwareAttestation", "AuditLog", "TRACE"],
+      "trustManifest": {
+        "identity": "spiffe://trust.agentrust.io/gateway/cmcp/prod",
+        "identityType": "spiffe",
+        "attestations": [
+          {
+            "type": "SPIFFE-X509",
+            "uri": "https://agentrust.io/.well-known/spiffe/jwks"
+          },
+          {
+            "type": "TRACE-v0.2",
+            "uri": "https://trace.agentrust.io/records/cmcp-prod-latest",
+            "digest": "sha256:3f4a8b2c1d9e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2"
+          }
+        ]
+      }
+    },
+    {
+      "identifier": "urn:ai:agentrust.io:governed:agent-manifest",
+      "displayName": "Agent Manifest SDK",
+      "description": "Hardware-anchors all 10 artifacts defining an agent at deployment. Attestation extended to agents — attested at registration and re-attested on any change.",
+      "type": "application/mcp-server+json",
+      "url": "https://api.agentrust.io/mcp/agent-manifest",
+      "version": "0.1.0",
+      "tags": ["governance", "identity", "attestation", "agent-manifest"],
+      "capabilities": ["AgentIdentity", "HardwareAttestation", "ManifestVerification"],
+      "trustManifest": {
+        "identity": "spiffe://trust.agentrust.io/service/agent-manifest/prod",
+        "identityType": "spiffe",
+        "attestations": [
+          {
+            "type": "SPIFFE-X509",
+            "uri": "https://agentrust.io/.well-known/spiffe/jwks"
+          },
+          {
+            "type": "TRACE-v0.2",
+            "uri": "https://trace.agentrust.io/records/agent-manifest-prod-latest",
+            "digest": "sha256:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"
+          }
+        ]
+      }
+    },
+    {
+      "identifier": "urn:ai:agentrust.io:governed:trace-registry",
+      "displayName": "TRACE Registry",
+      "description": "Public append-only Merkle registry for TRACE Trust Record anchors. Query attested session records for any TRACE-governed agent. Supports SCITT-anchored verification.",
+      "type": "application/mcp-server+json",
+      "url": "https://trace.agentrust.io/mcp",
+      "version": "0.2.0",
+      "tags": ["governance", "attestation", "trace", "audit", "scitt"],
+      "capabilities": ["TRACEVerification", "AuditQuery", "SCITTAnchoring"],
+      "trustManifest": {
+        "identity": "spiffe://trust.agentrust.io/service/trace-registry/prod",
+        "identityType": "spiffe",
+        "attestations": [
+          {
+            "type": "SPIFFE-X509",
+            "uri": "https://agentrust.io/.well-known/spiffe/jwks"
+          },
+          {
+            "type": "TRACE-v0.2",
+            "uri": "https://trace.agentrust.io/records/trace-registry-prod-latest",
+            "digest": "sha256:f0e9d8c7b6a5f4e3d2c1b0a9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c3b2a1f0e9"
+          }
+        ]
+      }
+    },
+    {
+      "identifier": "urn:ai:agentrust.io:registry:governed-agents",
+      "displayName": "agentrust.io Governed Agent Registry",
+      "description": "Federated ARD registry for TRACE-attested, policy-governed agents. All indexed entries carry TRACE-v0.2 runtime governance attestations. Filter with trustManifest.attestations.type=[TRACE-v0.2] to find governed agents across the federation.",
+      "type": "application/ai-registry+json",
+      "url": "https://registry.agentrust.io/api/v1/",
+      "tags": ["registry", "governance", "federation", "trace"]
+    }
+  ]
+}

--- a/spec/ard.md
+++ b/spec/ard.md
@@ -379,17 +379,51 @@ In addition to compliance certifications (SOC2-Type2, HIPAA-Audit), the attestat
 - The agent workload identity (SPIFFE SVID or DID)
 - Optional SCITT transparency log anchor for append-only external verifiability
 
-TRACE records are independently verifiable offline — a verifier holding the issuer's public key can confirm authenticity without contacting the issuing registry or the agent operator.
+TRACE records are independently verifiable offline -- a verifier holding the issuer's public key can confirm authenticity without contacting the issuing registry or the agent operator.
+
+Spec: [agentrust-io/trace-spec](https://agentrust-io.github.io/trace-spec/)
 
 **Example entry with TRACE runtime governance attestation:**
 
-
+```json
+{
+  "identifier": "urn:ai:agentrust.io:governed:cmcp-gateway",
+  "displayName": "Confidential MCP Gateway",
+  "type": "application/mcp-server+json",
+  "url": "https://api.agentrust.io/mcp/cmcp",
+  "tags": ["governance", "confidential-computing", "policy-enforcement"],
+  "trustManifest": {
+    "identity": "spiffe://trust.agentrust.io/gateway/cmcp/prod",
+    "identityType": "spiffe",
+    "attestations": [
+      {
+        "type": "SPIFFE-X509",
+        "uri": "https://agentrust.io/.well-known/spiffe/jwks"
+      },
+      {
+        "type": "TRACE-v0.2",
+        "uri": "https://trace.agentrust.io/records/cmcp-prod-latest",
+        "digest": "sha256:3f4a8b2c1d9e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2"
+      }
+    ]
+  }
+}
+```
 
 A TRACE attestation URI resolves to the TRACE Trust Record for the most recent attested session. For durable point-in-time records, the URI may reference a SCITT-anchored entry. The digest field SHOULD be the SHA-256 hash of the TRACE Trust Record JSON.
 
-**Discovery filter example — governed agents only:**
+**Discovery filter example -- governed agents only:**
 
-
+```json
+{
+  "query": {
+    "text": "policy-governed MCP gateway with hardware attestation",
+    "filter": {
+      "trustManifest.attestations.type": ["TRACE-v0.2"]
+    }
+  }
+}
+```
 
 Registries that index TRACE attestation types enable orchestrators to filter exclusively for agents with hardware-verifiable runtime governance records, without embedding trust logic in the orchestrator itself.
 

--- a/spec/ard.md
+++ b/spec/ard.md
@@ -363,9 +363,35 @@ Provides verifiable proof of a claim (e.g., compliance certifications).
 
 | Field | Type | Description |
 | :---- | :---- | :---- |
-| type | String | **Required**. Attestation type (e.g., "SOC2-Type2", "HIPAA-Audit"). |
+| type | String | **Required**. Attestation type (e.g., "SOC2-Type2", "HIPAA-Audit", "TRACE-v0.2"). |
 | uri | String | **Required**. Location of the attestation document. |
 | digest | String | Optional. Cryptographic hash for integrity verification. |
+
+### 5.2.1 Runtime Governance Attestations
+
+In addition to compliance certifications (SOC2-Type2, HIPAA-Audit), the attestation object accommodates **runtime governance attestations** — cryptographically signed records proving that an agent ran under a specific policy in a verified execution environment.
+
+**TRACE-v0.2** (Trust Runtime Attestation and Compliance Evidence) is a runtime governance attestation type. A TRACE Trust Record is an EAT-profile (RFC 9711) signed JSON artifact that encodes:
+
+- The Cedar policy bundle hash that governed the agent session
+- A tool-call transcript hash, chained via Merkle structure to the execution log
+- The hardware measurement of the execution environment (TEE platform, firmware, RIM)
+- The agent workload identity (SPIFFE SVID or DID)
+- Optional SCITT transparency log anchor for append-only external verifiability
+
+TRACE records are independently verifiable offline — a verifier holding the issuer's public key can confirm authenticity without contacting the issuing registry or the agent operator.
+
+**Example entry with TRACE runtime governance attestation:**
+
+
+
+A TRACE attestation URI resolves to the TRACE Trust Record for the most recent attested session. For durable point-in-time records, the URI may reference a SCITT-anchored entry. The digest field SHOULD be the SHA-256 hash of the TRACE Trust Record JSON.
+
+**Discovery filter example — governed agents only:**
+
+
+
+Registries that index TRACE attestation types enable orchestrators to filter exclusively for agents with hardware-verifiable runtime governance records, without embedding trust logic in the orchestrator itself.
 
 ### 5.3 Provenance Link Object
 

--- a/spec/ard.md
+++ b/spec/ard.md
@@ -387,7 +387,7 @@ Spec: [agentrust-io/trace-spec](https://agentrust-io.github.io/trace-spec/)
 
 ```json
 {
-  "identifier": "urn:ai:agentrust.io:governed:cmcp-gateway",
+  "identifier": "urn:air:agentrust.io:governed:cmcp-gateway",
   "displayName": "Confidential MCP Gateway",
   "type": "application/mcp-server+json",
   "url": "https://api.agentrust.io/mcp/cmcp",


### PR DESCRIPTION
## Summary

This PR adds **TRACE-v0.2** (Trust Runtime Attestation and Compliance Evidence) as a runtime governance attestation type in the ARD spec, alongside the existing compliance types (SOC2-Type2, HIPAA-Audit, SPIFFE-X509).

### What TRACE is

TRACE is an open EAT-profile (RFC 9711) standard that produces a cryptographically signed record proving an AI agent ran under a specific policy, in a verified hardware environment (TEE: AMD SEV-SNP, Intel TDX, NVIDIA H100 CC), with an auditable tool-call transcript — all in one independently verifiable artifact anchored to silicon attestation.

- **Spec + docs:** https://agentrust-io.github.io/trace-spec/
- **GitHub:** https://github.com/agentrust-io/trace-spec
- Developed in concert with [AGT](https://github.com/microsoft/agent-governance-toolkit) (microsoft/agent-governance-toolkit, 4,200+ stars, 100+ contributors)
- ADR filed in AGT: `docs/adr/0032-agt-emits-trace-v01-trust-records.md`
- Launching at Confidential Computing Summit June 23 2026

### Changes

1. **§5.2 Attestation Object** — `TRACE-v0.2` added to the `type` field examples alongside `SOC2-Type2` and `HIPAA-Audit`.

2. **§5.2.1 Runtime Governance Attestations** (new section) — explains the distinction between compliance certifications and runtime governance attestations, with:
   - A complete TRACE-attested catalog entry example
   - A discovery filter showing `trustManifest.attestations.type: ["TRACE-v0.2"]`
   - Guidance on what the `uri` and `digest` fields point to for a TRACE record
   - Link to the live spec docs

3. **`examples/agentrust-io-catalog.json`** — reference `ai-catalog.json` showing agentrust.io as a governed-agent federated ARD registry. Includes cMCP, Agent Manifest SDK, and TRACE Registry entries, each with SPIFFE-X509 + TRACE-v0.2 attestations.

### Why it matters for ARDS

The trustManifest already handles *what an agent claims about itself* (SOC2, HIPAA). TRACE fills the gap for *what an agent provably did at runtime* — the session evidence, not the certification. These are complementary: a registry can expose both `SOC2-Type2` (annual audit) and `TRACE-v0.2` (per-session hardware proof) on the same entry.

The `trustManifest.attestations.type` filter is already designed to support this — `["TRACE-v0.2"]` works today without any spec changes to the query model.

### Alignment notes

- TRACE `subject` field accepts both `spiffe://` and `did:` URIs, matching the `trustManifest.identity` field
- agentrust.io registers as `urn:ai:agentrust.io:registry:governed-agents` — a specialized federated registry returning only TRACE-attested entries
- The TRACE spec targets AAIF / Linux Foundation for long-term stewardship

Happy to iterate on the section placement, wording, or scope. The goal is minimal: one new attestation type in the table, one new section in §5, one reference example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)