### PR TITLE
fix: align explore query schema with optional text

### DIFF
--- a/spec/schemas/ard.cddl
+++ b/spec/schemas/ard.cddl
@@ -68,12 +68,17 @@ provenance-link = {
 ; --- The Search and Explore Registry API Payloads ---
 
 query-model = {
+  ? text: tstr,
+  ? filter: {* tstr => ([+ tstr] / tstr)}
+}
+
+search-query-model = {
   text: tstr,
   ? filter: {* tstr => ([+ tstr] / tstr)}
 }
 
 search-request = {
-  query: query-model,
+  query: search-query-model,
   ? federation: "auto" / "referrals" / "none",
   ? pageSize: uint,
   ? pageToken: tstr

--- a/spec/schemas/ard.openapi.yaml
+++ b/spec/schemas/ard.openapi.yaml
@@ -125,8 +125,6 @@ components:
   schemas:
     QueryModel:
       type: object
-      required:
-        - text
       properties:
         text:
           type: string
@@ -146,13 +144,20 @@ components:
             "trustManifest.attestations.type": ["SOC2-Type2"]
       additionalProperties: false
 
+    SearchQueryModel:
+      allOf:
+        - $ref: '#/components/schemas/QueryModel'
+        - type: object
+          required:
+            - text
+
     SearchRequest:
       type: object
       required:
         - query
       properties:
         query:
-          $ref: '#/components/schemas/QueryModel'
+          $ref: '#/components/schemas/SearchQueryModel'
         federation:
           type: string
           enum: [auto, referrals, none]
@@ -272,7 +277,7 @@ components:
           type: integer
           minimum: 0
           maximum: 100
-          description: Semantic relevance rating (0 to 100) computed by the registry. Note: This is not a security or trust score.
+          description: "Semantic relevance rating (0 to 100) computed by the registry. Note: This is not a security or trust score."
           example: 95
         source:
           type: string


### PR DESCRIPTION
## Summary

Align the formal ARD schemas with the spec text for `/explore`.

The spec says `/search` requires `query.text`, while `/explore` may be used with no `text` or `filter` so clients can request global registry facets. The OpenAPI and CDDL schemas currently share a `QueryModel` where `text` is required, which makes that valid `/explore` shape look invalid to generated clients.

## Changes

- Make the shared `QueryModel` allow optional `text` and `filter`
- Add a `SearchQueryModel` that keeps `text` required for `/search`
- Point `SearchRequest.query` at `SearchQueryModel`
- Mirror the same split in CDDL
- Quote one OpenAPI description containing `Note:` so the YAML parses with standard tooling

## Validation

- `./conformance/bin/run-conformance-demo`
- Parsed `spec/schemas/ard.openapi.yaml` with Ruby’s YAML parser