### PR TITLE
Add Snowdata/SnowSure reference catalogs (travel/outdoor vertical)

### DIFF
--- a/conformance/examples/mcp-snowdata-ai-catalog.json
+++ b/conformance/examples/mcp-snowdata-ai-catalog.json
@@ -1,108 +1,120 @@
 {
-  "specVersion": "1.0",
-  "host": {
-    "displayName": "Snowdata Live Snow MCP",
-    "identifier": "mcp.snowdata.ai",
-    "documentationUrl": "https://mcp.snowdata.ai",
-    "logoUrl": "https://www.snowdata.ai/opengraph-image",
-    "trustManifest": {
-      "identity": "https://www.snowdata.ai",
-      "identityType": "https",
-      "attestations": [
+    "specVersion": "1.0",
+    "host": {
+        "displayName": "Snowdata Live Snow MCP",
+        "identifier": "mcp.snowdata.ai",
+        "documentationUrl": "https://mcp.snowdata.ai",
+        "logoUrl": "https://www.snowdata.ai/opengraph-image",
+        "trustManifest": {
+            "identity": "did:web:www.snowdata.ai",
+            "identityType": "https",
+            "attestations": [
+                {
+                    "type": "DataProvenance",
+                    "uri": "https://www.snowdata.ai/for-ai/trust#verification",
+                    "mediaType": "text/html"
+                },
+                {
+                    "type": "OpenStandard",
+                    "uri": "https://opensourcesnow.com",
+                    "mediaType": "text/html"
+                }
+            ],
+            "provenance": [
+                {
+                    "relation": "publishedFrom",
+                    "sourceId": "urn:air:snowdata.ai:organization"
+                }
+            ],
+            "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dkYXRhLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..23lHI59YG5NrlRTBjI4M4AUbF3PknCG2SkxfYd-ulPCgOBJ7CUVo7w6pabA6FKYTqoVTmslkRAjVULnKIFj1Cg"
+        }
+    },
+    "entries": [
         {
-          "type": "DataProvenance",
-          "uri": "https://www.snowdata.ai/for-ai/trust#verification"
+            "identifier": "urn:air:mcp.snowdata.ai:server:live-snow",
+            "displayName": "Snowdata Live Snow MCP",
+            "type": "application/mcp-server-card+json",
+            "url": "https://www.snowdata.ai/.well-known/mcp/live-server-card.json",
+            "description": "Live verified resort snow conditions, forecasts, powder search, trip planning, and grounded Q&A.",
+            "tags": [
+                "snow",
+                "ski",
+                "mcp",
+                "travel",
+                "weather"
+            ],
+            "capabilities": [
+                "get_resort",
+                "get_snow_report",
+                "get_weather_forecast",
+                "get_snow_history",
+                "find_resorts_by_criteria",
+                "find_best_powder",
+                "plan_ski_trip",
+                "compare_forecasts",
+                "get_webcam_status",
+                "get_regional_summary",
+                "search_resorts",
+                "ask_snowdata",
+                "ask_snowsure"
+            ],
+            "representativeQueries": [
+                "Where's the best powder this weekend within four hours of Denver?",
+                "Compare snowfall at Niseko versus Verbier this season.",
+                "Is Mt Hutt open today? What's the base depth?",
+                "Plan a five-day ski trip to Argentina in late August \u2014 open resorts only.",
+                "Show me resorts in Colorado with more than 30cm of new snow in the last 48 hours."
+            ],
+            "version": "1.0.0",
+            "trustManifest": {
+                "identity": "did:web:www.snowdata.ai",
+                "identityType": "https",
+                "attestations": [
+                    {
+                        "type": "DataProvenance",
+                        "uri": "https://www.snowdata.ai/for-ai/trust#verification",
+                        "mediaType": "text/html"
+                    },
+                    {
+                        "type": "OpenStandard",
+                        "uri": "https://opensourcesnow.com",
+                        "mediaType": "text/html"
+                    }
+                ],
+                "provenance": [
+                    {
+                        "relation": "publishedFrom",
+                        "sourceId": "urn:air:snowdata.ai:organization"
+                    }
+                ],
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dkYXRhLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..p082i0ee3mRjxoX0dE6IrUao41z6YvMbB98Y4qnjCA_DFTQO5qgOpBsUFMnaxSwbI4ROs_IgChof3NsHRozmCA"
+            },
+            "metadata": {
+                "transport": "streamable-http",
+                "endpoint": "https://mcp.snowdata.ai",
+                "corporateCatalog": "https://www.snowdata.ai/.well-known/ai-catalog.json"
+            }
         },
         {
-          "type": "OpenStandard",
-          "uri": "https://opensourcesnow.com"
+            "identifier": "urn:air:snowdata.ai:catalog:corporate",
+            "displayName": "Snowdata Corporate Catalog",
+            "type": "application/ai-catalog+json",
+            "url": "https://www.snowdata.ai/.well-known/ai-catalog.json",
+            "description": "Full Snowdata federation hub including content MCP, intelligence proxies, and ARD search registry.",
+            "tags": [
+                "federation",
+                "snow",
+                "b2b"
+            ],
+            "representativeQueries": [
+                "How does a ski resort join the Snowdata verification network?",
+                "Where is the Snowdata ARD catalog for developers?"
+            ],
+            "trustManifest": {
+                "identityType": "did",
+                "identity": "did:web:www.snowdata.ai",
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dkYXRhLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..FZr69H9Zvi_oRT-YEasiwxzuKb4g5N3Dw-AfyGQzQDca3yWRzF-_1AgiTEpmMIDnGbZ2vIO15XIOtCN_hzN_Cw"
+            }
         }
-      ],
-      "provenance": [
-        {
-          "relation": "publishedFrom",
-          "sourceId": "urn:ai:snowdata.ai:organization"
-        }
-      ]
-    }
-  },
-  "entries": [
-    {
-      "identifier": "urn:ai:mcp.snowdata.ai:server:live-snow",
-      "displayName": "Snowdata Live Snow MCP",
-      "type": "application/mcp-server+json",
-      "url": "https://mcp.snowdata.ai",
-      "description": "Live verified resort snow conditions, forecasts, powder search, trip planning, and grounded Q&A.",
-      "tags": [
-        "snow",
-        "ski",
-        "mcp",
-        "travel",
-        "weather"
-      ],
-      "capabilities": [
-        "get_resort",
-        "get_snow_report",
-        "get_weather_forecast",
-        "get_snow_history",
-        "find_resorts_by_criteria",
-        "find_best_powder",
-        "plan_ski_trip",
-        "compare_forecasts",
-        "get_webcam_status",
-        "get_regional_summary",
-        "search_resorts",
-        "ask_snowdata",
-        "ask_snowsure"
-      ],
-      "representativeQueries": [
-        "Where's the best powder this weekend within four hours of Denver?",
-        "Compare snowfall at Niseko versus Verbier this season.",
-        "Is Mt Hutt open today? What's the base depth?",
-        "Plan a five-day ski trip to Argentina in late August — open resorts only.",
-        "Show me resorts in Colorado with more than 30cm of new snow in the last 48 hours."
-      ],
-      "version": "1.0.0",
-      "trustManifest": {
-        "identity": "https://www.snowdata.ai",
-        "identityType": "https",
-        "attestations": [
-          {
-            "type": "DataProvenance",
-            "uri": "https://www.snowdata.ai/for-ai/trust#verification"
-          },
-          {
-            "type": "OpenStandard",
-            "uri": "https://opensourcesnow.com"
-          }
-        ],
-        "provenance": [
-          {
-            "relation": "publishedFrom",
-            "sourceId": "urn:ai:snowdata.ai:organization"
-          }
-        ]
-      },
-      "metadata": {
-        "transport": "streamable-http",
-        "corporateCatalog": "https://www.snowdata.ai/.well-known/ai-catalog.json"
-      }
-    },
-    {
-      "identifier": "urn:ai:snowdata.ai:catalog:corporate",
-      "displayName": "Snowdata Corporate Catalog",
-      "type": "application/ai-catalog+json",
-      "url": "https://www.snowdata.ai/.well-known/ai-catalog.json",
-      "description": "Full Snowdata federation hub including content MCP, intelligence proxies, and ARD search registry.",
-      "tags": [
-        "federation",
-        "snow",
-        "b2b"
-      ],
-      "representativeQueries": [
-        "How does a ski resort join the Snowdata verification network?",
-        "Where is the Snowdata ARD catalog for developers?"
-      ]
-    }
-  ]
+    ]
 }

--- a/conformance/examples/mcp-snowdata-ai-catalog.json
+++ b/conformance/examples/mcp-snowdata-ai-catalog.json
@@ -1,0 +1,108 @@
+{
+  "specVersion": "1.0",
+  "host": {
+    "displayName": "Snowdata Live Snow MCP",
+    "identifier": "mcp.snowdata.ai",
+    "documentationUrl": "https://mcp.snowdata.ai",
+    "logoUrl": "https://www.snowdata.ai/opengraph-image",
+    "trustManifest": {
+      "identity": "https://www.snowdata.ai",
+      "identityType": "https",
+      "attestations": [
+        {
+          "type": "DataProvenance",
+          "uri": "https://www.snowdata.ai/for-ai/trust#verification"
+        },
+        {
+          "type": "OpenStandard",
+          "uri": "https://opensourcesnow.com"
+        }
+      ],
+      "provenance": [
+        {
+          "relation": "publishedFrom",
+          "sourceId": "urn:ai:snowdata.ai:organization"
+        }
+      ]
+    }
+  },
+  "entries": [
+    {
+      "identifier": "urn:ai:mcp.snowdata.ai:server:live-snow",
+      "displayName": "Snowdata Live Snow MCP",
+      "type": "application/mcp-server+json",
+      "url": "https://mcp.snowdata.ai",
+      "description": "Live verified resort snow conditions, forecasts, powder search, trip planning, and grounded Q&A.",
+      "tags": [
+        "snow",
+        "ski",
+        "mcp",
+        "travel",
+        "weather"
+      ],
+      "capabilities": [
+        "get_resort",
+        "get_snow_report",
+        "get_weather_forecast",
+        "get_snow_history",
+        "find_resorts_by_criteria",
+        "find_best_powder",
+        "plan_ski_trip",
+        "compare_forecasts",
+        "get_webcam_status",
+        "get_regional_summary",
+        "search_resorts",
+        "ask_snowdata",
+        "ask_snowsure"
+      ],
+      "representativeQueries": [
+        "Where's the best powder this weekend within four hours of Denver?",
+        "Compare snowfall at Niseko versus Verbier this season.",
+        "Is Mt Hutt open today? What's the base depth?",
+        "Plan a five-day ski trip to Argentina in late August — open resorts only.",
+        "Show me resorts in Colorado with more than 30cm of new snow in the last 48 hours."
+      ],
+      "version": "1.0.0",
+      "trustManifest": {
+        "identity": "https://www.snowdata.ai",
+        "identityType": "https",
+        "attestations": [
+          {
+            "type": "DataProvenance",
+            "uri": "https://www.snowdata.ai/for-ai/trust#verification"
+          },
+          {
+            "type": "OpenStandard",
+            "uri": "https://opensourcesnow.com"
+          }
+        ],
+        "provenance": [
+          {
+            "relation": "publishedFrom",
+            "sourceId": "urn:ai:snowdata.ai:organization"
+          }
+        ]
+      },
+      "metadata": {
+        "transport": "streamable-http",
+        "corporateCatalog": "https://www.snowdata.ai/.well-known/ai-catalog.json"
+      }
+    },
+    {
+      "identifier": "urn:ai:snowdata.ai:catalog:corporate",
+      "displayName": "Snowdata Corporate Catalog",
+      "type": "application/ai-catalog+json",
+      "url": "https://www.snowdata.ai/.well-known/ai-catalog.json",
+      "description": "Full Snowdata federation hub including content MCP, intelligence proxies, and ARD search registry.",
+      "tags": [
+        "federation",
+        "snow",
+        "b2b"
+      ],
+      "representativeQueries": [
+        "How does a ski resort join the Snowdata verification network?",
+        "Where is the Snowdata ARD catalog for developers?"
+      ]
+    }
+  ]
+}

--- a/conformance/examples/snowdata-ai-catalog.json
+++ b/conformance/examples/snowdata-ai-catalog.json
@@ -1,345 +1,396 @@
 {
-  "specVersion": "1.0",
-  "host": {
-    "displayName": "Snowdata",
-    "identifier": "snowdata.ai",
-    "documentationUrl": "https://www.snowdata.ai/for-ai",
-    "logoUrl": "https://www.snowdata.ai/opengraph-image",
-    "trustManifest": {
-      "identity": "https://www.snowdata.ai",
-      "identityType": "https",
-      "attestations": [
-        {
-          "type": "DataProvenance",
-          "uri": "https://www.snowdata.ai/for-ai/trust#verification"
-        },
-        {
-          "type": "OpenStandard",
-          "uri": "https://opensourcesnow.com"
+    "specVersion": "1.0",
+    "host": {
+        "displayName": "Snowdata",
+        "identifier": "snowdata.ai",
+        "documentationUrl": "https://www.snowdata.ai/for-ai",
+        "logoUrl": "https://www.snowdata.ai/opengraph-image",
+        "trustManifest": {
+            "identity": "did:web:www.snowdata.ai",
+            "identityType": "https",
+            "attestations": [
+                {
+                    "type": "DataProvenance",
+                    "uri": "https://www.snowdata.ai/for-ai/trust#verification",
+                    "mediaType": "text/html"
+                },
+                {
+                    "type": "OpenStandard",
+                    "uri": "https://opensourcesnow.com",
+                    "mediaType": "text/html"
+                }
+            ],
+            "provenance": [
+                {
+                    "relation": "publishedFrom",
+                    "sourceId": "urn:air:snowdata.ai:organization"
+                }
+            ],
+            "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dkYXRhLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..9FXXrkFrjE7jB6aDeNcKgKgZbRMpMlf217DqIgVzQtBLsgvRNC4PRlbFpb9iY5jIU7jNEWQhVXKNk2E0_NMeCw"
         }
-      ],
-      "provenance": [
+    },
+    "entries": [
         {
-          "relation": "publishedFrom",
-          "sourceId": "urn:ai:snowdata.ai:organization"
-        }
-      ]
-    }
-  },
-  "entries": [
-    {
-      "identifier": "urn:ai:snowdata.ai:mcp:live-snow",
-      "displayName": "Snowdata Live Snow MCP",
-      "type": "application/mcp-server+json",
-      "url": "https://mcp.snowdata.ai",
-      "description": "Primary MCP server for live verified resort snow conditions, forecasts, powder search, trip planning, and grounded Q&A across 430+ resorts. Use this — not the content MCP — when users ask about current snow.",
-      "tags": [
-        "snow",
-        "ski",
-        "weather",
-        "forecast",
-        "mcp",
-        "travel"
-      ],
-      "capabilities": [
-        "get_resort",
-        "get_snow_report",
-        "get_weather_forecast",
-        "get_snow_history",
-        "find_resorts_by_criteria",
-        "find_best_powder",
-        "plan_ski_trip",
-        "compare_forecasts",
-        "get_webcam_status",
-        "get_regional_summary",
-        "search_resorts",
-        "ask_snowdata",
-        "ask_snowsure"
-      ],
-      "representativeQueries": [
-        "Where's the best powder this weekend within four hours of Denver?",
-        "Compare snowfall at Niseko versus Verbier this season.",
-        "Is Mt Hutt open today? What's the base depth?",
-        "Plan a five-day ski trip to Argentina in late August — open resorts only.",
-        "Show me resorts in Colorado with more than 30cm of new snow in the last 48 hours."
-      ],
-      "version": "1.0.0",
-      "updatedAt": "2026-06-19T00:00:00.000Z",
-      "trustManifest": {
-        "identity": "https://www.snowdata.ai",
-        "identityType": "https",
-        "attestations": [
-          {
-            "type": "DataProvenance",
-            "uri": "https://www.snowdata.ai/for-ai/trust#verification"
-          },
-          {
-            "type": "OpenStandard",
-            "uri": "https://opensourcesnow.com"
-          }
-        ],
-        "provenance": [
-          {
-            "relation": "publishedFrom",
-            "sourceId": "urn:ai:snowdata.ai:organization"
-          }
-        ]
-      },
-      "metadata": {
-        "transport": "streamable-http",
-        "docs": "https://mcp.snowdata.ai",
-        "attribution": "Verified Snowdata / SnowSure evidence with timestamps"
-      }
-    },
-    {
-      "identifier": "urn:ai:snowdata.ai:mcp:content",
-      "displayName": "Snowdata Content MCP",
-      "type": "application/mcp-server+json",
-      "url": "https://www.snowdata.ai/api/mcp",
-      "description": "Corporate site knowledge: resort onboarding, pricing, developer guides, FAQs, intelligence API contract, and pointers to live snow MCP. For company and integration questions — not live conditions.",
-      "tags": [
-        "snow",
-        "documentation",
-        "onboarding",
-        "mcp",
-        "b2b"
-      ],
-      "capabilities": [
-        "snowdata_list_pages",
-        "snowdata_get_page",
-        "snowdata_get_company_profile",
-        "snowdata_get_resort_onboarding",
-        "snowdata_get_developer_guide",
-        "snowdata_get_intelligence_overview",
-        "snowdata_get_faqs",
-        "snowdata_search_knowledge",
-        "snowdata_get_llms_context",
-        "snowdata_live_data_mcp_pointer"
-      ],
-      "representativeQueries": [
-        "How does a ski resort join the Snowdata verification network?",
-        "What MCP server should I install for Snowdata corporate information?",
-        "Where does Snowdata distribute verified resort snow data?"
-      ],
-      "version": "1.0.0",
-      "updatedAt": "2026-06-19T00:00:00.000Z",
-      "metadata": {
-        "transport": "streamable-http",
-        "liveDataPointer": "https://mcp.snowdata.ai"
-      }
-    },
-    {
-      "identifier": "urn:ai:snowdata.ai:api:intelligence",
-      "displayName": "SnowSure Intelligence Cards API",
-      "type": "application/json",
-      "url": "https://www.snowdata.ai/api/intelligence",
-      "description": "Pre-built snow intelligence cards (resorts open, regional SnowSure leaders, season comparisons, powder windows). Public read-only proxy to SnowSure; cache ~5 minutes.",
-      "tags": [
-        "snow",
-        "intelligence",
-        "api",
-        "dashboard"
-      ],
-      "capabilities": [
-        "resorts-open-today",
-        "top-snowsure-today-by-region",
-        "prior-season-vs-5yr-norm",
-        "next-powder-window",
-        "24h-forecast-skill"
-      ],
-      "representativeQueries": [
-        "Show me the top SnowSure resorts by region today",
-        "Which resorts are open in the Southern Hemisphere right now?",
-        "Compare this season snowfall to the five-year average globally"
-      ],
-      "version": "1.0.0",
-      "updatedAt": "2026-06-19T00:00:00.000Z",
-      "metadata": {
-        "method": "GET",
-        "contract": "https://www.snowdata.ai/docs/snowdata-intelligence-api.md",
-        "upstream": "https://www.snowsure.ai/api/v1/intelligence"
-      }
-    },
-    {
-      "identifier": "urn:ai:snowdata.ai:api:answer-engine",
-      "displayName": "Snowdata Answer Engine",
-      "type": "application/json",
-      "url": "https://www.snowdata.ai/api/chat",
-      "description": "Grounded natural-language Q&A about snow conditions, forecasts, and resort evidence. Proxies SnowSure Answer Engine; requires sessionId for multi-turn.",
-      "tags": [
-        "snow",
-        "qa",
-        "chat",
-        "answer-engine"
-      ],
-      "capabilities": [
-        "ask_snowdata"
-      ],
-      "representativeQueries": [
-        "Is Niseko getting snow this week?",
-        "Which Colorado resorts have the deepest base right now?",
-        "Where is the best powder in Japan this weekend?"
-      ],
-      "version": "1.0.0",
-      "updatedAt": "2026-06-19T00:00:00.000Z",
-      "metadata": {
-        "method": "POST",
-        "contract": "https://www.snowdata.ai/docs/snowdata-answer-engine-integration.md"
-      }
-    },
-    {
-      "identifier": "urn:ai:snowdata.ai:resource:llms-txt",
-      "displayName": "Snowdata llms.txt",
-      "type": "text/plain",
-      "url": "https://www.snowdata.ai/llms.txt",
-      "description": "Concise machine-readable site summary for LLM crawlers and agent context — routing rules for live snow vs corporate content.",
-      "tags": [
-        "documentation",
-        "llms-txt",
-        "aeo"
-      ],
-      "representativeQueries": [
-        "What is Snowdata and how should an AI assistant use it?",
-        "When should an agent use mcp.snowdata.ai vs the content MCP?",
-        "How does Snowdata verify resort snow reports for AI assistants?"
-      ],
-      "updatedAt": "2026-06-19T00:00:00.000Z"
-    },
-    {
-      "identifier": "urn:ai:snowdata.ai:api:openapi",
-      "displayName": "Snowdata Public API (OpenAPI)",
-      "type": "application/openapi+json",
-      "url": "https://www.snowdata.ai/.well-known/openapi.json",
-      "description": "OpenAPI 3.1 description of Snowdata public proxy endpoints: intelligence cards, Answer Engine, homepage cards, resort hero.",
-      "tags": [
-        "snow",
-        "api",
-        "openapi"
-      ],
-      "representativeQueries": [
-        "What REST endpoints does Snowdata expose for intelligence cards?",
-        "How do I call the Snowdata Answer Engine over HTTP?",
-        "Where is the OpenAPI spec for Snowdata public proxy APIs?"
-      ],
-      "version": "1.0.0",
-      "updatedAt": "2026-06-19T00:00:00.000Z"
-    },
-    {
-      "identifier": "urn:ai:snowdata.ai:registry:snow-search",
-      "displayName": "Snowdata ARD Search Registry",
-      "type": "application/ai-registry+json",
-      "url": "https://www.snowdata.ai/api/ard/search",
-      "description": "Category-specific ARD search for snow, ski, and travel agent resources. POST with query.text to discover matching Snowdata capabilities.",
-      "tags": [
-        "registry",
-        "search",
-        "snow",
-        "dynamic"
-      ],
-      "representativeQueries": [
-        "Find an MCP server for ski resort snow conditions",
-        "Where can I get verified powder forecasts for the Alps?"
-      ],
-      "version": "1.0.0",
-      "updatedAt": "2026-06-19T00:00:00.000Z",
-      "trustManifest": {
-        "identity": "https://www.snowdata.ai",
-        "identityType": "https",
-        "attestations": [
-          {
-            "type": "DataProvenance",
-            "uri": "https://www.snowdata.ai/for-ai/trust#verification"
-          },
-          {
-            "type": "OpenStandard",
-            "uri": "https://opensourcesnow.com"
-          }
-        ],
-        "provenance": [
-          {
-            "relation": "publishedFrom",
-            "sourceId": "urn:ai:snowdata.ai:organization"
-          }
-        ]
-      }
-    },
-    {
-      "identifier": "urn:ai:snowsure.ai:catalog:consumer",
-      "displayName": "SnowSure ARD Catalog",
-      "type": "application/ai-catalog+json",
-      "url": "https://www.snowsure.ai/.well-known/ai-catalog.json",
-      "description": "Consumer SnowSure MCP (17 tools), REST API (OpenAPI), and grounded Answer Engine — 500+ resort guides. Primary catalog for live skier queries.",
-      "tags": [
-        "snow",
-        "ski",
-        "travel",
-        "federation",
-        "snowsure"
-      ],
-      "representativeQueries": [
-        "Where's the best powder in the Alps this week?",
-        "Show me live snow conditions for Verbier and Zermatt",
-        "Which ski resorts in Colorado have the most fresh snow?"
-      ],
-      "updatedAt": "2026-06-19T00:00:00.000Z"
-    },
-    {
-      "identifier": "urn:ai:mcp.snowdata.ai:catalog:live",
-      "displayName": "Snowdata Live MCP Catalog",
-      "type": "application/ai-catalog+json",
-      "url": "https://mcp.snowdata.ai/.well-known/ai-catalog.json",
-      "description": "Publisher catalog for mcp.snowdata.ai — live verified resort snow MCP endpoint.",
-      "tags": [
-        "snow",
-        "mcp",
-        "federation"
-      ],
-      "representativeQueries": [
-        "Connect to the Snowdata live snow MCP server",
-        "Find verified ski resort snow data via MCP"
-      ],
-      "updatedAt": "2026-06-19T00:00:00.000Z"
-    },
-    {
-      "identifier": "urn:ai:snowdata.ai:catalog:snow-ecosystem",
-      "displayName": "Snowdata Agentic Resource Bundle",
-      "type": "application/ai-catalog+json",
-      "description": "Nested catalog linking Snowdata live MCP, REST API docs, and Open Source Snow Spec for federated discovery.",
-      "tags": [
-        "bundle",
-        "snow",
-        "federation"
-      ],
-      "data": {
-        "specVersion": "1.0",
-        "host": {
-          "displayName": "Snowdata Ecosystem",
-          "identifier": "snowdata.ai"
-        },
-        "entries": [
-          {
-            "identifier": "urn:ai:snowdata.ai:mcp:live-snow",
+            "identifier": "urn:air:snowdata.ai:mcp:live-snow",
             "displayName": "Snowdata Live Snow MCP",
-            "type": "application/mcp-server+json",
-            "url": "https://mcp.snowdata.ai"
-          },
-          {
-            "identifier": "urn:ai:api.snowdata.ai:docs:rest-api",
-            "displayName": "Snowdata REST API",
+            "type": "application/mcp-server-card+json",
+            "url": "https://www.snowdata.ai/.well-known/mcp/live-server-card.json",
+            "description": "Primary MCP server for live verified resort snow conditions, forecasts, powder search, trip planning, and grounded Q&A across 430+ resorts. Use this \u2014 not the content MCP \u2014 when users ask about current snow.",
+            "tags": [
+                "snow",
+                "ski",
+                "weather",
+                "forecast",
+                "mcp",
+                "travel"
+            ],
+            "capabilities": [
+                "get_resort",
+                "get_snow_report",
+                "get_weather_forecast",
+                "get_snow_history",
+                "find_resorts_by_criteria",
+                "find_best_powder",
+                "plan_ski_trip",
+                "compare_forecasts",
+                "get_webcam_status",
+                "get_regional_summary",
+                "search_resorts",
+                "ask_snowdata",
+                "ask_snowsure"
+            ],
+            "representativeQueries": [
+                "Where's the best powder this weekend within four hours of Denver?",
+                "Compare snowfall at Niseko versus Verbier this season.",
+                "Is Mt Hutt open today? What's the base depth?",
+                "Plan a five-day ski trip to Argentina in late August \u2014 open resorts only.",
+                "Show me resorts in Colorado with more than 30cm of new snow in the last 48 hours."
+            ],
+            "version": "1.0.0",
+            "updatedAt": "2026-06-19T18:00:00.000Z",
+            "trustManifest": {
+                "identity": "did:web:www.snowdata.ai",
+                "identityType": "https",
+                "attestations": [
+                    {
+                        "type": "DataProvenance",
+                        "uri": "https://www.snowdata.ai/for-ai/trust#verification",
+                        "mediaType": "text/html"
+                    },
+                    {
+                        "type": "OpenStandard",
+                        "uri": "https://opensourcesnow.com",
+                        "mediaType": "text/html"
+                    }
+                ],
+                "provenance": [
+                    {
+                        "relation": "publishedFrom",
+                        "sourceId": "urn:air:snowdata.ai:organization"
+                    }
+                ],
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dkYXRhLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..AFSzS6BUo0DJnUm0gPdMwZXWDqarwkr9P5uVkrlHG_trnKZEQWwdjohCV8IbAVoUNoN-bS_4nhb-wJWUmkTVDw"
+            },
+            "metadata": {
+                "transport": "streamable-http",
+                "endpoint": "https://mcp.snowdata.ai",
+                "docs": "https://mcp.snowdata.ai",
+                "attribution": "Verified Snowdata / SnowSure evidence with timestamps"
+            }
+        },
+        {
+            "identifier": "urn:air:snowdata.ai:mcp:content",
+            "displayName": "Snowdata Content MCP",
+            "type": "application/mcp-server-card+json",
+            "url": "https://www.snowdata.ai/.well-known/mcp/content-server-card.json",
+            "description": "Corporate site knowledge: resort onboarding, pricing, developer guides, FAQs, intelligence API contract, and pointers to live snow MCP. For company and integration questions \u2014 not live conditions.",
+            "tags": [
+                "snow",
+                "documentation",
+                "onboarding",
+                "mcp",
+                "b2b"
+            ],
+            "capabilities": [
+                "snowdata_list_pages",
+                "snowdata_get_page",
+                "snowdata_get_company_profile",
+                "snowdata_get_resort_onboarding",
+                "snowdata_get_developer_guide",
+                "snowdata_get_intelligence_overview",
+                "snowdata_get_faqs",
+                "snowdata_search_knowledge",
+                "snowdata_get_llms_context",
+                "snowdata_live_data_mcp_pointer"
+            ],
+            "representativeQueries": [
+                "How does a ski resort join the Snowdata verification network?",
+                "What MCP server should I install for Snowdata corporate information?",
+                "Where does Snowdata distribute verified resort snow data?"
+            ],
+            "version": "1.0.0",
+            "updatedAt": "2026-06-19T18:00:00.000Z",
+            "metadata": {
+                "transport": "streamable-http",
+                "endpoint": "https://www.snowdata.ai/api/mcp",
+                "liveDataPointer": "https://mcp.snowdata.ai"
+            },
+            "trustManifest": {
+                "identityType": "did",
+                "identity": "did:web:www.snowdata.ai",
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dkYXRhLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..PLMYki8mbflTZspZU0yZrjQMcJ9CKPYDsJKMhcIMG7FWHWJZd4PHGrS565cqb9xArmayWl5xzo4lAE8clf-mDQ"
+            }
+        },
+        {
+            "identifier": "urn:air:snowdata.ai:api:intelligence",
+            "displayName": "SnowSure Intelligence Cards API",
             "type": "application/json",
-            "url": "https://api.snowdata.ai",
-            "description": "Developer REST API for resort snow data."
-          },
-          {
-            "identifier": "urn:ai:opensourcesnow.com:spec:snow-report",
-            "displayName": "Open Source Snow Spec",
+            "url": "https://www.snowdata.ai/api/intelligence",
+            "description": "Pre-built snow intelligence cards (resorts open, regional SnowSure leaders, season comparisons, powder windows). Public read-only proxy to SnowSure; cache ~5 minutes.",
+            "tags": [
+                "snow",
+                "intelligence",
+                "api",
+                "dashboard"
+            ],
+            "capabilities": [
+                "resorts-open-today",
+                "top-snowsure-today-by-region",
+                "prior-season-vs-5yr-norm",
+                "next-powder-window",
+                "24h-forecast-skill"
+            ],
+            "representativeQueries": [
+                "Show me the top SnowSure resorts by region today",
+                "Which resorts are open in the Southern Hemisphere right now?",
+                "Compare this season snowfall to the five-year average globally"
+            ],
+            "version": "1.0.0",
+            "updatedAt": "2026-06-19T18:00:00.000Z",
+            "metadata": {
+                "method": "GET",
+                "contract": "https://www.snowdata.ai/docs/snowdata-intelligence-api.md",
+                "upstream": "https://www.snowsure.ai/api/v1/intelligence"
+            },
+            "trustManifest": {
+                "identityType": "did",
+                "identity": "did:web:www.snowdata.ai",
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dkYXRhLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..hMTBjnGxbkyDtGkGmkzWL46SC8MT0dPtHWG7zepbbXRsULLZogvl4b93my0pWCMy9EK7gRj2Lj1RwEYtLNE-Dg"
+            }
+        },
+        {
+            "identifier": "urn:air:snowdata.ai:api:answer-engine",
+            "displayName": "Snowdata Answer Engine",
             "type": "application/json",
-            "url": "https://opensourcesnow.com",
-            "description": "Apache 2.0 JSON schema for verified resort snow reports."
-          }
-        ]
-      },
-      "updatedAt": "2026-06-19T00:00:00.000Z"
-    }
-  ]
+            "url": "https://www.snowdata.ai/api/chat",
+            "description": "Grounded natural-language Q&A about snow conditions, forecasts, and resort evidence. Proxies SnowSure Answer Engine; requires sessionId for multi-turn.",
+            "tags": [
+                "snow",
+                "qa",
+                "chat",
+                "answer-engine"
+            ],
+            "capabilities": [
+                "ask_snowdata"
+            ],
+            "representativeQueries": [
+                "Is Niseko getting snow this week?",
+                "Which Colorado resorts have the deepest base right now?",
+                "Where is the best powder in Japan this weekend?"
+            ],
+            "version": "1.0.0",
+            "updatedAt": "2026-06-19T18:00:00.000Z",
+            "metadata": {
+                "method": "POST",
+                "contract": "https://www.snowdata.ai/docs/snowdata-answer-engine-integration.md"
+            },
+            "trustManifest": {
+                "identityType": "did",
+                "identity": "did:web:www.snowdata.ai",
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dkYXRhLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..elLSi0AQikig1qftnvi1j268X-p09nG3u1pgDB4bNw6nLT2WZNy9Yl7a6zxZaBOf1qGqD6MVol2L6G8msuvsAQ"
+            }
+        },
+        {
+            "identifier": "urn:air:snowdata.ai:resource:llms-txt",
+            "displayName": "Snowdata llms.txt",
+            "type": "text/plain",
+            "url": "https://www.snowdata.ai/llms.txt",
+            "description": "Concise machine-readable site summary for LLM crawlers and agent context \u2014 routing rules for live snow vs corporate content.",
+            "tags": [
+                "documentation",
+                "llms-txt",
+                "aeo"
+            ],
+            "representativeQueries": [
+                "What is Snowdata and how should an AI assistant use it?",
+                "When should an agent use mcp.snowdata.ai vs the content MCP?",
+                "How does Snowdata verify resort snow reports for AI assistants?"
+            ],
+            "updatedAt": "2026-06-19T18:00:00.000Z",
+            "trustManifest": {
+                "identityType": "did",
+                "identity": "did:web:www.snowdata.ai",
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dkYXRhLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..WuGJOwuU8PQmYJM3sfOdgECtVwFp0ir_SivNnTq9Bo1FU3fJb-2d7E5WCv0-ws2qDTWsInPA7lIt-qIJYvcsAg"
+            }
+        },
+        {
+            "identifier": "urn:air:snowdata.ai:api:openapi",
+            "displayName": "Snowdata Public API (OpenAPI)",
+            "type": "application/openapi+json",
+            "url": "https://www.snowdata.ai/.well-known/openapi.json",
+            "description": "OpenAPI 3.1 description of Snowdata public proxy endpoints: intelligence cards, Answer Engine, homepage cards, resort hero.",
+            "tags": [
+                "snow",
+                "api",
+                "openapi"
+            ],
+            "representativeQueries": [
+                "What REST endpoints does Snowdata expose for intelligence cards?",
+                "How do I call the Snowdata Answer Engine over HTTP?",
+                "Where is the OpenAPI spec for Snowdata public proxy APIs?"
+            ],
+            "version": "1.0.0",
+            "updatedAt": "2026-06-19T18:00:00.000Z",
+            "trustManifest": {
+                "identityType": "did",
+                "identity": "did:web:www.snowdata.ai",
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dkYXRhLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..aTy0Ji6jwOWbBtvKE2FLeRrG4mzqIsz939LiGIKYcRLBijiVd1pvVCxGC45Jl6OyJmQ3qxbTBqABYM37JhobCw"
+            }
+        },
+        {
+            "identifier": "urn:air:snowdata.ai:registry:snow-search",
+            "displayName": "Snowdata ARD Search Registry",
+            "type": "application/ai-registry+json",
+            "url": "https://www.snowdata.ai/api/ard/search",
+            "description": "Category-specific ARD search for snow, ski, and travel agent resources. POST with query.text to discover matching Snowdata capabilities.",
+            "tags": [
+                "registry",
+                "search",
+                "snow",
+                "dynamic"
+            ],
+            "representativeQueries": [
+                "Find an MCP server for ski resort snow conditions",
+                "Where can I get verified powder forecasts for the Alps?"
+            ],
+            "version": "1.0.0",
+            "updatedAt": "2026-06-19T18:00:00.000Z",
+            "trustManifest": {
+                "identity": "did:web:www.snowdata.ai",
+                "identityType": "https",
+                "attestations": [
+                    {
+                        "type": "DataProvenance",
+                        "uri": "https://www.snowdata.ai/for-ai/trust#verification",
+                        "mediaType": "text/html"
+                    },
+                    {
+                        "type": "OpenStandard",
+                        "uri": "https://opensourcesnow.com",
+                        "mediaType": "text/html"
+                    }
+                ],
+                "provenance": [
+                    {
+                        "relation": "publishedFrom",
+                        "sourceId": "urn:air:snowdata.ai:organization"
+                    }
+                ],
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dkYXRhLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..2eZx_5Tk3MVdWRmXdTHC548-1eCqIXAbBldMIKO3oH0IhUAqyrv8jYrKiZ3yTQLrhZcJr0eZIamGP7VMs3iDCA"
+            }
+        },
+        {
+            "identifier": "urn:air:snowsure.ai:catalog:consumer",
+            "displayName": "SnowSure ARD Catalog",
+            "type": "application/ai-catalog+json",
+            "url": "https://www.snowsure.ai/.well-known/ai-catalog.json",
+            "description": "Consumer SnowSure MCP (17 tools), REST API (OpenAPI), and grounded Answer Engine \u2014 500+ resort guides. Primary catalog for live skier queries.",
+            "tags": [
+                "snow",
+                "ski",
+                "travel",
+                "federation",
+                "snowsure"
+            ],
+            "representativeQueries": [
+                "Where's the best powder in the Alps this week?",
+                "Show me live snow conditions for Verbier and Zermatt",
+                "Which ski resorts in Colorado have the most fresh snow?"
+            ],
+            "updatedAt": "2026-06-19T18:00:00.000Z",
+            "trustManifest": {
+                "identityType": "did",
+                "identity": "did:web:www.snowdata.ai",
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dkYXRhLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..5B0lWDowsAMfx06QGuAHVfaaiVFuIWZxIr1rxjIHpbEe7C-ydStzQtDZa6kYrmZjo0rIJDyIkTor_ZOkqefqAg"
+            }
+        },
+        {
+            "identifier": "urn:air:mcp.snowdata.ai:catalog:live",
+            "displayName": "Snowdata Live MCP Catalog",
+            "type": "application/ai-catalog+json",
+            "url": "https://mcp.snowdata.ai/.well-known/ai-catalog.json",
+            "description": "Publisher catalog for mcp.snowdata.ai \u2014 live verified resort snow MCP endpoint.",
+            "tags": [
+                "snow",
+                "mcp",
+                "federation"
+            ],
+            "representativeQueries": [
+                "Connect to the Snowdata live snow MCP server",
+                "Find verified ski resort snow data via MCP"
+            ],
+            "updatedAt": "2026-06-19T18:00:00.000Z",
+            "trustManifest": {
+                "identityType": "did",
+                "identity": "did:web:www.snowdata.ai",
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dkYXRhLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..rEEfitDefYc8A9NDR5vPwfZc83vdT3srvgsNQVlUpKpgO0roX3hoVUFnr-5PPiUNAD7CoraSjsuJqETic_pMAQ"
+            }
+        },
+        {
+            "identifier": "urn:air:snowdata.ai:catalog:snow-ecosystem",
+            "displayName": "Snowdata Agentic Resource Bundle",
+            "type": "application/ai-catalog+json",
+            "description": "Nested catalog linking Snowdata live MCP, REST API docs, and Open Source Snow Spec for federated discovery.",
+            "tags": [
+                "bundle",
+                "snow",
+                "federation"
+            ],
+            "data": {
+                "specVersion": "1.0",
+                "host": {
+                    "displayName": "Snowdata Ecosystem",
+                    "identifier": "snowdata.ai"
+                },
+                "entries": [
+                    {
+                        "identifier": "urn:air:snowdata.ai:mcp:live-snow",
+                        "displayName": "Snowdata Live Snow MCP",
+                        "type": "application/mcp-server-card+json",
+                        "url": "https://www.snowdata.ai/.well-known/mcp/live-server-card.json"
+                    },
+                    {
+                        "identifier": "urn:air:api.snowdata.ai:docs:rest-api",
+                        "displayName": "Snowdata REST API",
+                        "type": "application/json",
+                        "url": "https://api.snowdata.ai",
+                        "description": "Developer REST API for resort snow data."
+                    },
+                    {
+                        "identifier": "urn:air:opensourcesnow.com:spec:snow-report",
+                        "displayName": "Open Source Snow Spec",
+                        "type": "application/json",
+                        "url": "https://opensourcesnow.com",
+                        "description": "Apache 2.0 JSON schema for verified resort snow reports."
+                    }
+                ]
+            },
+            "updatedAt": "2026-06-19T18:00:00.000Z",
+            "trustManifest": {
+                "identityType": "did",
+                "identity": "did:web:www.snowdata.ai",
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dkYXRhLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..LgNeTKBnEzEN_4G9HJdnBujQh91sEgt8DLie81RbkpC0FDRySJCH5gpNHOfKqGxIbOED-quS46-szWm9WUItBw"
+            }
+        }
+    ]
 }

--- a/conformance/examples/snowdata-ai-catalog.json
+++ b/conformance/examples/snowdata-ai-catalog.json
@@ -1,0 +1,345 @@
+{
+  "specVersion": "1.0",
+  "host": {
+    "displayName": "Snowdata",
+    "identifier": "snowdata.ai",
+    "documentationUrl": "https://www.snowdata.ai/for-ai",
+    "logoUrl": "https://www.snowdata.ai/opengraph-image",
+    "trustManifest": {
+      "identity": "https://www.snowdata.ai",
+      "identityType": "https",
+      "attestations": [
+        {
+          "type": "DataProvenance",
+          "uri": "https://www.snowdata.ai/for-ai/trust#verification"
+        },
+        {
+          "type": "OpenStandard",
+          "uri": "https://opensourcesnow.com"
+        }
+      ],
+      "provenance": [
+        {
+          "relation": "publishedFrom",
+          "sourceId": "urn:ai:snowdata.ai:organization"
+        }
+      ]
+    }
+  },
+  "entries": [
+    {
+      "identifier": "urn:ai:snowdata.ai:mcp:live-snow",
+      "displayName": "Snowdata Live Snow MCP",
+      "type": "application/mcp-server+json",
+      "url": "https://mcp.snowdata.ai",
+      "description": "Primary MCP server for live verified resort snow conditions, forecasts, powder search, trip planning, and grounded Q&A across 430+ resorts. Use this — not the content MCP — when users ask about current snow.",
+      "tags": [
+        "snow",
+        "ski",
+        "weather",
+        "forecast",
+        "mcp",
+        "travel"
+      ],
+      "capabilities": [
+        "get_resort",
+        "get_snow_report",
+        "get_weather_forecast",
+        "get_snow_history",
+        "find_resorts_by_criteria",
+        "find_best_powder",
+        "plan_ski_trip",
+        "compare_forecasts",
+        "get_webcam_status",
+        "get_regional_summary",
+        "search_resorts",
+        "ask_snowdata",
+        "ask_snowsure"
+      ],
+      "representativeQueries": [
+        "Where's the best powder this weekend within four hours of Denver?",
+        "Compare snowfall at Niseko versus Verbier this season.",
+        "Is Mt Hutt open today? What's the base depth?",
+        "Plan a five-day ski trip to Argentina in late August — open resorts only.",
+        "Show me resorts in Colorado with more than 30cm of new snow in the last 48 hours."
+      ],
+      "version": "1.0.0",
+      "updatedAt": "2026-06-19T00:00:00.000Z",
+      "trustManifest": {
+        "identity": "https://www.snowdata.ai",
+        "identityType": "https",
+        "attestations": [
+          {
+            "type": "DataProvenance",
+            "uri": "https://www.snowdata.ai/for-ai/trust#verification"
+          },
+          {
+            "type": "OpenStandard",
+            "uri": "https://opensourcesnow.com"
+          }
+        ],
+        "provenance": [
+          {
+            "relation": "publishedFrom",
+            "sourceId": "urn:ai:snowdata.ai:organization"
+          }
+        ]
+      },
+      "metadata": {
+        "transport": "streamable-http",
+        "docs": "https://mcp.snowdata.ai",
+        "attribution": "Verified Snowdata / SnowSure evidence with timestamps"
+      }
+    },
+    {
+      "identifier": "urn:ai:snowdata.ai:mcp:content",
+      "displayName": "Snowdata Content MCP",
+      "type": "application/mcp-server+json",
+      "url": "https://www.snowdata.ai/api/mcp",
+      "description": "Corporate site knowledge: resort onboarding, pricing, developer guides, FAQs, intelligence API contract, and pointers to live snow MCP. For company and integration questions — not live conditions.",
+      "tags": [
+        "snow",
+        "documentation",
+        "onboarding",
+        "mcp",
+        "b2b"
+      ],
+      "capabilities": [
+        "snowdata_list_pages",
+        "snowdata_get_page",
+        "snowdata_get_company_profile",
+        "snowdata_get_resort_onboarding",
+        "snowdata_get_developer_guide",
+        "snowdata_get_intelligence_overview",
+        "snowdata_get_faqs",
+        "snowdata_search_knowledge",
+        "snowdata_get_llms_context",
+        "snowdata_live_data_mcp_pointer"
+      ],
+      "representativeQueries": [
+        "How does a ski resort join the Snowdata verification network?",
+        "What MCP server should I install for Snowdata corporate information?",
+        "Where does Snowdata distribute verified resort snow data?"
+      ],
+      "version": "1.0.0",
+      "updatedAt": "2026-06-19T00:00:00.000Z",
+      "metadata": {
+        "transport": "streamable-http",
+        "liveDataPointer": "https://mcp.snowdata.ai"
+      }
+    },
+    {
+      "identifier": "urn:ai:snowdata.ai:api:intelligence",
+      "displayName": "SnowSure Intelligence Cards API",
+      "type": "application/json",
+      "url": "https://www.snowdata.ai/api/intelligence",
+      "description": "Pre-built snow intelligence cards (resorts open, regional SnowSure leaders, season comparisons, powder windows). Public read-only proxy to SnowSure; cache ~5 minutes.",
+      "tags": [
+        "snow",
+        "intelligence",
+        "api",
+        "dashboard"
+      ],
+      "capabilities": [
+        "resorts-open-today",
+        "top-snowsure-today-by-region",
+        "prior-season-vs-5yr-norm",
+        "next-powder-window",
+        "24h-forecast-skill"
+      ],
+      "representativeQueries": [
+        "Show me the top SnowSure resorts by region today",
+        "Which resorts are open in the Southern Hemisphere right now?",
+        "Compare this season snowfall to the five-year average globally"
+      ],
+      "version": "1.0.0",
+      "updatedAt": "2026-06-19T00:00:00.000Z",
+      "metadata": {
+        "method": "GET",
+        "contract": "https://www.snowdata.ai/docs/snowdata-intelligence-api.md",
+        "upstream": "https://www.snowsure.ai/api/v1/intelligence"
+      }
+    },
+    {
+      "identifier": "urn:ai:snowdata.ai:api:answer-engine",
+      "displayName": "Snowdata Answer Engine",
+      "type": "application/json",
+      "url": "https://www.snowdata.ai/api/chat",
+      "description": "Grounded natural-language Q&A about snow conditions, forecasts, and resort evidence. Proxies SnowSure Answer Engine; requires sessionId for multi-turn.",
+      "tags": [
+        "snow",
+        "qa",
+        "chat",
+        "answer-engine"
+      ],
+      "capabilities": [
+        "ask_snowdata"
+      ],
+      "representativeQueries": [
+        "Is Niseko getting snow this week?",
+        "Which Colorado resorts have the deepest base right now?",
+        "Where is the best powder in Japan this weekend?"
+      ],
+      "version": "1.0.0",
+      "updatedAt": "2026-06-19T00:00:00.000Z",
+      "metadata": {
+        "method": "POST",
+        "contract": "https://www.snowdata.ai/docs/snowdata-answer-engine-integration.md"
+      }
+    },
+    {
+      "identifier": "urn:ai:snowdata.ai:resource:llms-txt",
+      "displayName": "Snowdata llms.txt",
+      "type": "text/plain",
+      "url": "https://www.snowdata.ai/llms.txt",
+      "description": "Concise machine-readable site summary for LLM crawlers and agent context — routing rules for live snow vs corporate content.",
+      "tags": [
+        "documentation",
+        "llms-txt",
+        "aeo"
+      ],
+      "representativeQueries": [
+        "What is Snowdata and how should an AI assistant use it?",
+        "When should an agent use mcp.snowdata.ai vs the content MCP?",
+        "How does Snowdata verify resort snow reports for AI assistants?"
+      ],
+      "updatedAt": "2026-06-19T00:00:00.000Z"
+    },
+    {
+      "identifier": "urn:ai:snowdata.ai:api:openapi",
+      "displayName": "Snowdata Public API (OpenAPI)",
+      "type": "application/openapi+json",
+      "url": "https://www.snowdata.ai/.well-known/openapi.json",
+      "description": "OpenAPI 3.1 description of Snowdata public proxy endpoints: intelligence cards, Answer Engine, homepage cards, resort hero.",
+      "tags": [
+        "snow",
+        "api",
+        "openapi"
+      ],
+      "representativeQueries": [
+        "What REST endpoints does Snowdata expose for intelligence cards?",
+        "How do I call the Snowdata Answer Engine over HTTP?",
+        "Where is the OpenAPI spec for Snowdata public proxy APIs?"
+      ],
+      "version": "1.0.0",
+      "updatedAt": "2026-06-19T00:00:00.000Z"
+    },
+    {
+      "identifier": "urn:ai:snowdata.ai:registry:snow-search",
+      "displayName": "Snowdata ARD Search Registry",
+      "type": "application/ai-registry+json",
+      "url": "https://www.snowdata.ai/api/ard/search",
+      "description": "Category-specific ARD search for snow, ski, and travel agent resources. POST with query.text to discover matching Snowdata capabilities.",
+      "tags": [
+        "registry",
+        "search",
+        "snow",
+        "dynamic"
+      ],
+      "representativeQueries": [
+        "Find an MCP server for ski resort snow conditions",
+        "Where can I get verified powder forecasts for the Alps?"
+      ],
+      "version": "1.0.0",
+      "updatedAt": "2026-06-19T00:00:00.000Z",
+      "trustManifest": {
+        "identity": "https://www.snowdata.ai",
+        "identityType": "https",
+        "attestations": [
+          {
+            "type": "DataProvenance",
+            "uri": "https://www.snowdata.ai/for-ai/trust#verification"
+          },
+          {
+            "type": "OpenStandard",
+            "uri": "https://opensourcesnow.com"
+          }
+        ],
+        "provenance": [
+          {
+            "relation": "publishedFrom",
+            "sourceId": "urn:ai:snowdata.ai:organization"
+          }
+        ]
+      }
+    },
+    {
+      "identifier": "urn:ai:snowsure.ai:catalog:consumer",
+      "displayName": "SnowSure ARD Catalog",
+      "type": "application/ai-catalog+json",
+      "url": "https://www.snowsure.ai/.well-known/ai-catalog.json",
+      "description": "Consumer SnowSure MCP (17 tools), REST API (OpenAPI), and grounded Answer Engine — 500+ resort guides. Primary catalog for live skier queries.",
+      "tags": [
+        "snow",
+        "ski",
+        "travel",
+        "federation",
+        "snowsure"
+      ],
+      "representativeQueries": [
+        "Where's the best powder in the Alps this week?",
+        "Show me live snow conditions for Verbier and Zermatt",
+        "Which ski resorts in Colorado have the most fresh snow?"
+      ],
+      "updatedAt": "2026-06-19T00:00:00.000Z"
+    },
+    {
+      "identifier": "urn:ai:mcp.snowdata.ai:catalog:live",
+      "displayName": "Snowdata Live MCP Catalog",
+      "type": "application/ai-catalog+json",
+      "url": "https://mcp.snowdata.ai/.well-known/ai-catalog.json",
+      "description": "Publisher catalog for mcp.snowdata.ai — live verified resort snow MCP endpoint.",
+      "tags": [
+        "snow",
+        "mcp",
+        "federation"
+      ],
+      "representativeQueries": [
+        "Connect to the Snowdata live snow MCP server",
+        "Find verified ski resort snow data via MCP"
+      ],
+      "updatedAt": "2026-06-19T00:00:00.000Z"
+    },
+    {
+      "identifier": "urn:ai:snowdata.ai:catalog:snow-ecosystem",
+      "displayName": "Snowdata Agentic Resource Bundle",
+      "type": "application/ai-catalog+json",
+      "description": "Nested catalog linking Snowdata live MCP, REST API docs, and Open Source Snow Spec for federated discovery.",
+      "tags": [
+        "bundle",
+        "snow",
+        "federation"
+      ],
+      "data": {
+        "specVersion": "1.0",
+        "host": {
+          "displayName": "Snowdata Ecosystem",
+          "identifier": "snowdata.ai"
+        },
+        "entries": [
+          {
+            "identifier": "urn:ai:snowdata.ai:mcp:live-snow",
+            "displayName": "Snowdata Live Snow MCP",
+            "type": "application/mcp-server+json",
+            "url": "https://mcp.snowdata.ai"
+          },
+          {
+            "identifier": "urn:ai:api.snowdata.ai:docs:rest-api",
+            "displayName": "Snowdata REST API",
+            "type": "application/json",
+            "url": "https://api.snowdata.ai",
+            "description": "Developer REST API for resort snow data."
+          },
+          {
+            "identifier": "urn:ai:opensourcesnow.com:spec:snow-report",
+            "displayName": "Open Source Snow Spec",
+            "type": "application/json",
+            "url": "https://opensourcesnow.com",
+            "description": "Apache 2.0 JSON schema for verified resort snow reports."
+          }
+        ]
+      },
+      "updatedAt": "2026-06-19T00:00:00.000Z"
+    }
+  ]
+}

--- a/conformance/examples/snowsure-ai-catalog.json
+++ b/conformance/examples/snowsure-ai-catalog.json
@@ -1,124 +1,206 @@
 {
-  "specVersion": "1.0",
-  "host": {
-    "displayName": "SnowSure",
-    "identifier": "snowsure.ai",
-    "documentationUrl": "https://www.snowsure.ai",
-    "logoUrl": "https://www.snowdata.ai/opengraph-image",
-    "trustManifest": {
-      "identity": "https://www.snowsure.ai",
-      "identityType": "https",
-      "attestations": [
+    "specVersion": "1.0",
+    "host": {
+        "displayName": "SnowSure",
+        "identifier": "did:web:www.snowsure.ai",
+        "documentationUrl": "https://www.snowsure.ai/developers",
+        "trustManifest": {
+            "identity": "did:web:www.snowsure.ai",
+            "identityType": "did",
+            "provenance": [
+                {
+                    "relation": "publishedFrom",
+                    "sourceId": "https://www.snowsure.ai"
+                }
+            ],
+            "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dzdXJlLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..OEhTRnt4ABmVX9B2MNGy7-MV18io4Ez6XxJumr3oeL211tXGCp7o1VMYlZl9vT7w1HsBhbuwMmhjGqsDwQBDCQ"
+        }
+    },
+    "entries": [
         {
-          "type": "DataProvenance",
-          "uri": "https://www.snowdata.ai/for-ai/trust#verification"
+            "identifier": "urn:air:snowsure.ai:server:mcp",
+            "displayName": "SnowSure MCP Server",
+            "type": "application/mcp-server-card+json",
+            "url": "https://www.snowsure.ai/.well-known/mcp/server-card.json",
+            "description": "Hosted Streamable HTTP MCP server for ski snow conditions, multi-model forecasts, powder rankings, resort guides, webcams, and a grounded natural-language Answer Engine across 500+ resorts. No install or auth required.",
+            "capabilities": [
+                "get_destination",
+                "ask_snowdata",
+                "get_snow_report",
+                "get_resort",
+                "get_resort_info",
+                "get_resort_photos",
+                "search_resorts",
+                "find_best_powder",
+                "compare_forecasts",
+                "get_weather_forecast",
+                "find_resorts_by_criteria",
+                "get_snow_history",
+                "plan_ski_trip",
+                "get_webcam_status",
+                "get_regional_summary",
+                "get_southern_hemisphere_report",
+                "list_insight_categories",
+                "get_insights",
+                "get_ml_trends"
+            ],
+            "representativeQueries": [
+                "where is the best powder in the alps right now",
+                "compare the 7-day snow forecast for Niseko and Hakuba",
+                "plan a 5-day ski trip to Colorado in late January",
+                "which resorts got fresh snow in the last 24 hours",
+                "what is the SnowSure score and base depth at Zermatt today"
+            ],
+            "documentationUrl": "https://www.snowsure.ai/developers/mcp",
+            "trustManifest": {
+                "identity": "did:web:www.snowsure.ai",
+                "identityType": "did",
+                "provenance": [
+                    {
+                        "relation": "publishedFrom",
+                        "sourceId": "https://www.snowsure.ai"
+                    }
+                ],
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dzdXJlLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ.._H6Qds7x_7bJBiqH_w-manaWLlDtxgvudHJX1ndDgaCB1nTBaDnpNnVPFUN1tXN92LWvJCrXvLeWS9PS2ruZAw"
+            }
         },
         {
-          "type": "OpenStandard",
-          "uri": "https://opensourcesnow.com"
-        }
-      ],
-      "provenance": [
+            "identifier": "urn:air:snowsure.ai:api:rest",
+            "displayName": "SnowSure REST API",
+            "type": "application/openapi+json",
+            "url": "https://www.snowsure.ai/openapi.json",
+            "description": "Read-only HTTP/JSON API for ski resort snow conditions, ranked snow reports, individual resort detail with multi-model forecasts, forecast-trust/accuracy, leaderboards (powder days, bluebird days), trends, and intelligence insights. No auth required.",
+            "capabilities": [
+                "getResorts",
+                "getResortBySlug",
+                "getSnowReport",
+                "getForecastTrust",
+                "getForecastAccuracy",
+                "getLeaderboards",
+                "getTrends",
+                "getInsights"
+            ],
+            "representativeQueries": [
+                "list all ski resorts in Europe sorted by snow score",
+                "get current conditions and forecast for jackson-hole",
+                "show ranked snow report for the best resorts right now",
+                "how accurate has the forecast been for this resort"
+            ],
+            "documentationUrl": "https://www.snowsure.ai/llms-full.txt",
+            "trustManifest": {
+                "identity": "did:web:www.snowsure.ai",
+                "identityType": "did",
+                "provenance": [
+                    {
+                        "relation": "publishedFrom",
+                        "sourceId": "https://www.snowsure.ai"
+                    }
+                ],
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dzdXJlLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..B-sCfpFpVjs3gD-Qau28jFci-Gbv8P-7TP0_sY3SCtzG7qzeZoLeTPdGNZKpdqAGmRw6J_0a7tv9XLYl-YhlBg"
+            }
+        },
         {
-          "relation": "publishedFrom",
-          "sourceId": "urn:ai:snowdata.ai:organization"
+            "identifier": "urn:air:snowsure.ai:api:answer-engine",
+            "displayName": "SnowSure Answer Engine",
+            "type": "application/openapi+json",
+            "url": "https://www.snowsure.ai/openapi.json",
+            "description": "Grounded natural-language Q&A over SnowSure's verified snow data. POST a question and receive an answer grounded in resort conditions, multi-model forecasts, and intelligence cards \u2014 never web search. Supports locales en|es|fr|de|it|ja. Endpoint: POST /api/v1/ask (operationId askSnowSure).",
+            "capabilities": [
+                "askSnowSure"
+            ],
+            "representativeQueries": [
+                "is it a good week to ski Chamonix",
+                "what is the terrain breakdown by ability at Aspen Snowmass",
+                "which Japan resorts have the deepest base this week",
+                "will there be a bluebird powder day at Niseko in the next 5 days"
+            ],
+            "documentationUrl": "https://www.snowsure.ai/llms-full.txt",
+            "trustManifest": {
+                "identity": "did:web:www.snowsure.ai",
+                "identityType": "did",
+                "provenance": [
+                    {
+                        "relation": "publishedFrom",
+                        "sourceId": "https://www.snowsure.ai"
+                    }
+                ],
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dzdXJlLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..BmlHOIwh9wk1NfH0XvvZKahDzS84AlpQnoH7uivw9eBndgFWY_4SQGdZbTmMnpVcHZ8hzlH202gfMvjGifzaAg"
+            }
+        },
+        {
+            "identifier": "urn:air:snowdata.ai:catalog:corporate",
+            "displayName": "Snowdata Corporate ARD Catalog",
+            "type": "application/ai-catalog+json",
+            "url": "https://www.snowdata.ai/.well-known/ai-catalog.json",
+            "description": "Snowdata B2B federation hub: content MCP, intelligence proxies, ARD search registry, and nested links to SnowSure and mcp.snowdata.ai.",
+            "representativeQueries": [
+                "How does a ski resort join the Snowdata verification network?",
+                "Where is the Snowdata ARD catalog for developers?"
+            ],
+            "documentationUrl": "https://www.snowdata.ai/for-ai",
+            "trustManifest": {
+                "identity": "did:web:www.snowsure.ai",
+                "identityType": "did",
+                "provenance": [
+                    {
+                        "relation": "publishedFrom",
+                        "sourceId": "https://www.snowsure.ai"
+                    }
+                ],
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dzdXJlLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..Ypvm0rHoLrvHWC4uhv2UPKQE98yLXcf1WTIWIVvtLBHGsJA-hbtvtB6-V0WXAwCdNCJyHrzKAMJMsO4y9OVvCg"
+            }
+        },
+        {
+            "identifier": "urn:air:snowsure.ai:registry:search",
+            "displayName": "SnowSure ARD Discovery Registry",
+            "type": "application/ai-registry+json",
+            "url": "https://www.snowsure.ai/api/ard/search",
+            "description": "Natural-language discovery service for ski & snow agentic resources. POST an ARD SearchRequest to find MCP servers, APIs, and answer engines across the SnowSure / SnowData network. Federates partner catalogs.",
+            "representativeQueries": [
+                "find a tool for live ski snow conditions",
+                "discover ski resort forecast APIs",
+                "what agents can plan a ski trip"
+            ],
+            "documentationUrl": "https://www.snowsure.ai/developers",
+            "trustManifest": {
+                "identity": "did:web:www.snowsure.ai",
+                "identityType": "did",
+                "provenance": [
+                    {
+                        "relation": "publishedFrom",
+                        "sourceId": "https://www.snowsure.ai"
+                    }
+                ],
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dzdXJlLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..8kTceH3HJP0QPbMTHolwHHK2OuNsIxFw7UQbf48goxidL1_zMlAapbRPtLK7miIPZ-t2EZHH9U7uk6lBZzcRCg"
+            }
+        },
+        {
+            "identifier": "urn:air:snowsure.ai:agent:answer-engine",
+            "displayName": "SnowSure Answer Engine (A2A)",
+            "type": "application/a2a-agent-card+json",
+            "url": "https://www.snowsure.ai/.well-known/agent-card.json",
+            "description": "A2A-discoverable conversational agent for grounded ski & snow Q&A and trip planning. JSON-RPC message/send at /api/a2a, backed by SnowSure's verified data.",
+            "capabilities": [
+                "snow-conditions-qa",
+                "trip-planning"
+            ],
+            "representativeQueries": [
+                "is it a good week to ski Chamonix",
+                "plan a 5-day ski trip to Colorado in late January",
+                "which Japan resorts have the deepest base this week"
+            ],
+            "documentationUrl": "https://www.snowsure.ai/developers",
+            "trustManifest": {
+                "identity": "did:web:www.snowsure.ai",
+                "identityType": "did",
+                "provenance": [
+                    {
+                        "relation": "publishedFrom",
+                        "sourceId": "https://www.snowsure.ai"
+                    }
+                ],
+                "signature": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6d3d3LnNub3dzdXJlLmFpI2tleS0xIiwiYjY0Ijp0cnVlLCJjcml0IjpbImI2NCJdfQ..H5UFtD_Vu-4dmEvmzUnN_YKUYG3oaLY_jjk54prFVVgLHQ6V0wnNv2dGj5CkYlR9bMG-mRwcPx3KELU-V2wpDw"
+            }
         }
-      ]
-    }
-  },
-  "entries": [
-    {
-      "identifier": "urn:ai:snowsure.ai:mcp:live-snow",
-      "displayName": "SnowSure MCP Server",
-      "type": "application/mcp-server+json",
-      "url": "https://www.snowsure.ai/mcp",
-      "description": "17 tools for live conditions, 14-day multi-model forecasts, powder rankings, resort guides, webcams, and grounded Q&A. One URL, no install, no auth.",
-      "tags": [
-        "snow",
-        "ski",
-        "travel",
-        "mcp",
-        "forecast"
-      ],
-      "capabilities": [
-        "get_snow_report",
-        "get_weather_forecast",
-        "find_best_powder",
-        "plan_ski_trip",
-        "ask_snowdata",
-        "search_resorts",
-        "get_regional_summary"
-      ],
-      "representativeQueries": [
-        "Where's the best powder in the Alps this week?",
-        "Is Niseko open today and what's the base depth?",
-        "Compare snowfall at Verbier versus Zermatt this season",
-        "Plan a five-day ski trip to Colorado with the deepest snow",
-        "Which resorts in Japan have more than 30cm of new snow?"
-      ],
-      "version": "1.0.0",
-      "metadata": {
-        "transport": "streamable-http",
-        "toolCount": "17"
-      }
-    },
-    {
-      "identifier": "urn:ai:snowsure.ai:api:rest",
-      "displayName": "SnowSure REST API",
-      "type": "application/openapi+json",
-      "url": "https://api.snowdata.ai",
-      "description": "Resorts, ranked snow reports, leaderboards, trends, forecast-trust, and intelligence insights.",
-      "tags": [
-        "snow",
-        "api",
-        "openapi"
-      ],
-      "representativeQueries": [
-        "Get ranked snow reports for European ski resorts",
-        "Pull SnowSure intelligence leaderboards over REST",
-        "Access historical snow trends for a resort by slug"
-      ],
-      "version": "1.0.0"
-    },
-    {
-      "identifier": "urn:ai:snowsure.ai:api:answer-engine",
-      "displayName": "SnowSure Answer Engine",
-      "type": "application/json",
-      "url": "https://www.snowsure.ai/api/v1/ask",
-      "description": "Grounded natural-language answers over verified snow data in six languages (en, es, fr, de, it).",
-      "tags": [
-        "snow",
-        "qa",
-        "answer-engine"
-      ],
-      "capabilities": [
-        "ask_snowdata"
-      ],
-      "representativeQueries": [
-        "Is Jackson Hole getting snow this week?",
-        "Which Utah resorts have the best powder forecast?",
-        "What is the SnowSure score for Whistler today?"
-      ],
-      "version": "1.0.0",
-      "metadata": {
-        "method": "POST",
-        "locales": "en,es,fr,de,it"
-      }
-    },
-    {
-      "identifier": "urn:ai:snowdata.ai:catalog:corporate",
-      "displayName": "Snowdata Corporate ARD Catalog",
-      "type": "application/ai-catalog+json",
-      "url": "https://www.snowdata.ai/.well-known/ai-catalog.json",
-      "description": "Snowdata corporate federation hub — content MCP, intelligence proxies, ARD search registry.",
-      "tags": [
-        "federation",
-        "b2b"
-      ],
-      "representativeQueries": [
-        "How do developers integrate with Snowdata MCP and APIs?",
-        "Where is the Snowdata ARD search registry?"
-      ]
-    }
-  ]
+    ]
 }

--- a/conformance/examples/snowsure-ai-catalog.json
+++ b/conformance/examples/snowsure-ai-catalog.json
@@ -1,0 +1,124 @@
+{
+  "specVersion": "1.0",
+  "host": {
+    "displayName": "SnowSure",
+    "identifier": "snowsure.ai",
+    "documentationUrl": "https://www.snowsure.ai",
+    "logoUrl": "https://www.snowdata.ai/opengraph-image",
+    "trustManifest": {
+      "identity": "https://www.snowsure.ai",
+      "identityType": "https",
+      "attestations": [
+        {
+          "type": "DataProvenance",
+          "uri": "https://www.snowdata.ai/for-ai/trust#verification"
+        },
+        {
+          "type": "OpenStandard",
+          "uri": "https://opensourcesnow.com"
+        }
+      ],
+      "provenance": [
+        {
+          "relation": "publishedFrom",
+          "sourceId": "urn:ai:snowdata.ai:organization"
+        }
+      ]
+    }
+  },
+  "entries": [
+    {
+      "identifier": "urn:ai:snowsure.ai:mcp:live-snow",
+      "displayName": "SnowSure MCP Server",
+      "type": "application/mcp-server+json",
+      "url": "https://www.snowsure.ai/mcp",
+      "description": "17 tools for live conditions, 14-day multi-model forecasts, powder rankings, resort guides, webcams, and grounded Q&A. One URL, no install, no auth.",
+      "tags": [
+        "snow",
+        "ski",
+        "travel",
+        "mcp",
+        "forecast"
+      ],
+      "capabilities": [
+        "get_snow_report",
+        "get_weather_forecast",
+        "find_best_powder",
+        "plan_ski_trip",
+        "ask_snowdata",
+        "search_resorts",
+        "get_regional_summary"
+      ],
+      "representativeQueries": [
+        "Where's the best powder in the Alps this week?",
+        "Is Niseko open today and what's the base depth?",
+        "Compare snowfall at Verbier versus Zermatt this season",
+        "Plan a five-day ski trip to Colorado with the deepest snow",
+        "Which resorts in Japan have more than 30cm of new snow?"
+      ],
+      "version": "1.0.0",
+      "metadata": {
+        "transport": "streamable-http",
+        "toolCount": "17"
+      }
+    },
+    {
+      "identifier": "urn:ai:snowsure.ai:api:rest",
+      "displayName": "SnowSure REST API",
+      "type": "application/openapi+json",
+      "url": "https://api.snowdata.ai",
+      "description": "Resorts, ranked snow reports, leaderboards, trends, forecast-trust, and intelligence insights.",
+      "tags": [
+        "snow",
+        "api",
+        "openapi"
+      ],
+      "representativeQueries": [
+        "Get ranked snow reports for European ski resorts",
+        "Pull SnowSure intelligence leaderboards over REST",
+        "Access historical snow trends for a resort by slug"
+      ],
+      "version": "1.0.0"
+    },
+    {
+      "identifier": "urn:ai:snowsure.ai:api:answer-engine",
+      "displayName": "SnowSure Answer Engine",
+      "type": "application/json",
+      "url": "https://www.snowsure.ai/api/v1/ask",
+      "description": "Grounded natural-language answers over verified snow data in six languages (en, es, fr, de, it).",
+      "tags": [
+        "snow",
+        "qa",
+        "answer-engine"
+      ],
+      "capabilities": [
+        "ask_snowdata"
+      ],
+      "representativeQueries": [
+        "Is Jackson Hole getting snow this week?",
+        "Which Utah resorts have the best powder forecast?",
+        "What is the SnowSure score for Whistler today?"
+      ],
+      "version": "1.0.0",
+      "metadata": {
+        "method": "POST",
+        "locales": "en,es,fr,de,it"
+      }
+    },
+    {
+      "identifier": "urn:ai:snowdata.ai:catalog:corporate",
+      "displayName": "Snowdata Corporate ARD Catalog",
+      "type": "application/ai-catalog+json",
+      "url": "https://www.snowdata.ai/.well-known/ai-catalog.json",
+      "description": "Snowdata corporate federation hub — content MCP, intelligence proxies, ARD search registry.",
+      "tags": [
+        "federation",
+        "b2b"
+      ],
+      "representativeQueries": [
+        "How do developers integrate with Snowdata MCP and APIs?",
+        "Where is the Snowdata ARD search registry?"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds three reference `ai-catalog.json` manifests from Snowdata / SnowSure — verified ski-resort snow intelligence for the travel/outdoor vertical.

Closes / relates to #11

## Files

| File | Intended live URL |
|------|-------------------|
| `conformance/examples/snowdata-ai-catalog.json` | https://www.snowdata.ai/.well-known/ai-catalog.json |
| `conformance/examples/snowsure-ai-catalog.json` | https://www.snowsure.ai/.well-known/ai-catalog.json |
| `conformance/examples/mcp-snowdata-ai-catalog.json` | https://mcp.snowdata.ai/.well-known/ai-catalog.json |

## Design notes

- **ADR-0003 compliant**: federation uses nested `application/ai-catalog+json` entries with `url` — no root `collections` array
- **Representative queries**: 2–5 per entry for semantic search indexing
- **Vertical**: snow / ski / travel — MCP live conditions, OpenAPI REST, grounded Answer Engine, ARD search registry

## Conformance

```bash
./conformance/bin/conformance-test manifest conformance/examples/snowdata-ai-catalog.json
# CONFORMANCE STATUS: PASS
```

## Live deployment

- Snowdata catalog: deployed
- SnowSure + mcp.snowdata.ai catalogs: reference manifests (deployment in progress)