### PR TITLE
docs: add "Implementations in the wild" (5 conformance-tested ARD dep…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ this is the single source of truth.
 - [`adr/`](adr/) — architecture decision records
 - [`conformance/`](conformance/) — conformance test tooling
 
+## Implementations in the wild
+
+Independent, conformance-tested ARD deployments (validated with this repo's `conformance/` CLI):
+
+| Publisher | Domain | Role | Conformance |
+|---|---|---|---|
+| SnowSure | snowsure.ai | Discovery registry (ski & snow) + publisher | PASS |
+| SnowData | snowdata.ai | Discovery registry (ski & snow) + publisher | PASS |
+| Afore | afo.re | Discovery registry (editorial travel) + publisher | PASS |
+| LUXSKI | lux.ski | Publisher | PASS |
+| Ski Limone | skilimone.com | Publisher | PASS |
+
+Five independent `did:web` publishers; three run live ARD `POST /search` registries with cross-federation. Reference registry: `POST https://www.snowsure.ai/search`.
+
 ## Status
 
 **v0.9 (Draft).** The specification is open and evolving; feedback and proposals


### PR DESCRIPTION
Adds an "Implementations in the wild" section to the README listing five independent, conformance-tested ARD deployments.

All five pass this repo's conformance CLI (`conformance/bin/conformance-test manifest <url>`) with zero critical errors: SnowSure (snowsure.ai) and SnowData (snowdata.ai) are ski & snow discovery registries + publishers; Afore (afo.re) is an editorial-travel discovery registry + publisher; LUXSKI (lux.ski) and Ski Limone (skilimone.com) are publishers.

Three of them run live ARD `POST /search` registries with cross-federation; all entries carry did:web + Ed25519 entry-bound detached JWS (keys at /.well-known/did.json). Context in #11. Happy to adjust placement or wording to your preference.