### PR TITLE
Align OpenAPI filter schema with scalar filter values

### DIFF
--- a/spec/schemas/ard.openapi.yaml
+++ b/spec/schemas/ard.openapi.yaml
@@ -136,9 +136,11 @@ components:
             Structured constraints. Keys are field paths (can be dot-separated for nested fields). 
             Values are arrays or scalar values.
           additionalProperties:
-            type: array
-            items:
-              type: string
+            oneOf:
+              - type: string
+              - type: array
+                items:
+                  type: string
           example:
             type: ["application/mcp-server-card+json"]
             "trustManifest.attestations.type": ["SOC2-Type2"]


### PR DESCRIPTION
## Summary

This updates the OpenAPI schema for `QueryModel.filter` values to match the existing prose spec and CDDL.

The documented contract already allows scalar filter values:

- [`spec/ard.md`, Query Model field table](https://github.com/ards-project/ard-spec/blob/a78be70591bc5301cc4c3955ff0c0b5e523f3f2b/spec/ard.md?plain=1#L429): `values are arrays (a bare scalar is accepted as a single-element array)`.
- [`spec/schemas/ard.cddl`, `query-model`](https://github.com/ards-project/ard-spec/blob/a78be70591bc5301cc4c3955ff0c0b5e523f3f2b/spec/schemas/ard.cddl#L70-L72): `? filter: {* tstr => ([+ tstr] / tstr)}`.
- [`spec/schemas/ard.openapi.yaml`, `QueryModel.filter` description](https://github.com/ards-project/ard-spec/blob/a78be70591bc5301cc4c3955ff0c0b5e523f3f2b/spec/schemas/ard.openapi.yaml#L133-L138): `Values are arrays or scalar values.`

However, before this PR, the formal OpenAPI schema only allowed `array<string>`, so generated clients could reject scalar filter values even though the prose and CDDL allow them.

## Change

- Update `QueryModel.filter.additionalProperties` from `array<string>` to `oneOf: string | array<string>`.

## Notes

This does not change the documented API contract. It makes the machine-readable OpenAPI schema match the existing prose and CDDL behavior so generated clients can represent scalar filter values correctly.