### PR TITLE
fix: handle optional 'description' in example registry server

### DIFF
--- a/conformance/examples/ai-catalog.json
+++ b/conformance/examples/ai-catalog.json
@@ -34,6 +34,12 @@
       "type": "application/ai-catalog+json",
       "url": "https://acme.com/catalogs/engineering.json",
       "description": "Nested catalog containing CI/CD and internal deployment agents."
+    },
+    {
+      "identifier": "urn:air:acme.com:tool:unit-converter",
+      "displayName": "Unit Converter",
+      "type": "application/mcp-server-card+json",
+      "url": "https://api.acme.com/mcp/unit-converter.json"
     }
   ]
 }

--- a/conformance/examples/registry-server.py
+++ b/conformance/examples/registry-server.py
@@ -45,6 +45,12 @@ MOCK_CATALOG_ENTRIES = [
     "type": "application/ai-catalog+json",
     "url": "https://acme.com/catalogs/engineering.json",
     "description": "Nested catalog containing CI/CD and internal deployment agents."
+  },
+  {
+    "identifier": "urn:air:acme.com:tool:unit-converter",
+    "displayName": "Unit Converter",
+    "type": "application/mcp-server-card+json",
+    "url": "https://api.acme.com/mcp/unit-converter.json"
   }
 ]
 
@@ -113,7 +119,7 @@ class MockRegistryHandler(BaseHTTPRequestHandler):
                 matched = False
 
                 # Match text against keywords in display name, description, or representative queries
-                if query_text in entry["displayName"].lower() or query_text in entry["description"].lower():
+                if query_text in entry["displayName"].lower() or query_text in entry.get("description", "").lower():
                     score += 30
                     matched = True
                 


### PR DESCRIPTION
Hit this while poking at the conformance demo: `description` is optional (§4.2), but the example registry assumes it's always there, so a valid catalog that omits it just 500s on `/search`. Small fix, but the demo never covered that path so I added a case for it too.

**What changed**
- `registry-server.py`: search matches on `entry.get("description", "")` instead of `entry["description"]`
- added a description-less entry to the mock catalog + `examples/ai-catalog.json` (kept in sync) so `run-conformance-demo` actually exercises the optional path

**Before / after**
- before: manifest validation passes, but the `/search` probe dies with `Remote end closed connection`
- after: demo's green end to end