### PR TITLE
test: cover zero-dependency conformance mode

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -19,6 +19,9 @@ jobs:
       with:
         python-version: '3.11'
 
+    - name: Run manifest validation without dependencies
+      run: python -S ./conformance/bin/conformance-test manifest ./conformance/examples/ai-catalog.json
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary

Adds a small CI check for the conformance CLI's zero-dependency manifest validation path.

The conformance tool is documented as zero-dependency, and `jsonschema` is optional. Existing CI installs `jsonschema` before running the full demo, so it only exercises the enhanced schema-validation path.

This PR adds a pre-install check using `python -S` to verify that manifest validation still works without site-packages.

## Changes

- Run `conformance-test manifest` before installing dependencies
- Use `python -S` so optional packages such as `jsonschema` are not available from site-packages
- Keep the existing `jsonschema`-enabled conformance demo unchanged

## Validation

Ran locally:

```bash
python3 -S ./conformance/bin/conformance-test manifest ./conformance/examples/ai-catalog.json
./conformance/bin/run-conformance-demo
git diff --check
```
