### PR TITLE
Change identifier prefix from 'urn:air' to 'urn:ai'

### DIFF
--- a/adr/0009-urn-nid-length-air.md
+++ b/adr/0009-urn-nid-length-air.md
@@ -10,11 +10,11 @@ The Agentic Resource Discovery (ARD) specification initially utilized the `urn:a
 We are changing the primary URN namespace identifier (NID) from `ai` to `air` to ensure the NID is at least three characters long. 
 
 The new pattern will be:
-`urn:air:<publisher>:<namespace>:<agent-name>`
+`urn:ai:<publisher>:<namespace>:<agent-name>`
 
 This change also aligns with the latest agreed alignments across with ai-catalog.
 
 ## Consequences
-- All schema references, OpenAPI documents, CDDL specifications, and mock data have been updated to use `urn:air:` instead of `urn:ai:`.
+- All schema references, OpenAPI documents, CDDL specifications, and mock data have been updated to use `urn:ai:` instead of `urn:ai:`.
 - This ensures full compliance with standard URN parsers and avoids short-identifier constraint issues.
 - Implementers must update their identifier schemas to use the `air` NID.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -63,7 +63,7 @@ When checking a capability manifest (`ai-catalog.json`), the tool executes the f
 * **JSON Structural Integrity**: Parses the manifest payload to ensure it is valid, uncorrupted JSON.
 * **JSON Schema Draft 2020-12 Conformance**: If the Python `jsonschema` library is installed (`pip install jsonschema`), the tool automatically runs a strict schema-level validation using the official [ai-catalog.schema.json](../spec/schemas/ai-catalog.schema.json) file.
 * **Strict URN Pattern Matching**: Enforces that each entry's `identifier` adheres strictly to the domain-anchored URN namespace format defined in the spec:
-  `urn:air:<publisher>:<namespace>:<agent-name>` (RFC 8141).
+  `urn:ai:<publisher>:<namespace>:<agent-name>` (RFC 8141).
 * **Value-or-Reference Delivery**: Enforces the mutual exclusivity constraint of the specification. Each entry **MUST** contain precisely one of either `"url"` (remote reference) or `"data"` (embedded payload), and will fail if both or neither are provided.
 * **Ecosystem Attributes Validation**:
   * Checks that `"representativeQueries"` contains between **2 to 5** natural-language queries to ensure high-performance semantic vector embeddings.

--- a/conformance/bin/conformance-test
+++ b/conformance/bin/conformance-test
@@ -11,8 +11,8 @@ import json
 import urllib.request
 import urllib.error
 
-# Strict URN Regex matching urn:air:<publisher>:<namespace>:<agent-name>
-URN_REGEX = re.compile(r"^urn:air:([a-zA-Z0-9.-]+)(?::([a-zA-Z0-9._:-]+))?:([a-zA-Z0-9._-]+)$")
+# Strict URN Regex matching urn:ai:<publisher>:<namespace>:<agent-name>
+URN_REGEX = re.compile(r"^urn:ai:([a-zA-Z0-9.-]+)(?::([a-zA-Z0-9._:-]+))?:([a-zA-Z0-9._-]+)$")
 
 # Colors for beautiful CLI output
 COLOR_RESET = "\033[0m"
@@ -125,7 +125,7 @@ class ConformanceTester:
                 # URN pattern checks
                 match = URN_REGEX.match(ident)
                 if not match:
-                    self.add_error(f"[{label}] Identifier '{ident}' does not match RFC 8141 URN pattern 'urn:air:<publisher>:<namespace>:<agent-name>'.")
+                    self.add_error(f"[{label}] Identifier '{ident}' does not match RFC 8141 URN pattern 'urn:ai:<publisher>:<namespace>:<agent-name>'.")
                 else:
                     publisher, namespace, name = match.groups()
                     print_success(f"[{label}] Valid URN format. Publisher: '{publisher}', Name: '{name}'.")
@@ -145,7 +145,7 @@ class ConformanceTester:
                     "application/mcp-server-card+json",
                     "application/agent-skills+zip",
                     "application/agent-skills+gzip",
-                    "text/markdown; profile=\"urn:air:agent-skills\"",
+                    "text/markdown; profile=\"urn:ai:agent-skills\"",
                     "application/ai-registry",
                     "application/ai-registry+json"
                 ]

--- a/conformance/examples/ai-catalog.json
+++ b/conformance/examples/ai-catalog.json
@@ -6,7 +6,7 @@
   },
   "entries": [
     {
-      "identifier": "urn:air:acme.com:agent:assistant",
+      "identifier": "urn:ai:acme.com:agent:assistant",
       "displayName": "Corporate Assistant (A2A)",
       "type": "application/a2a-agent-card+json",
       "url": "https://api.acme.com/agents/assistant.json",
@@ -17,7 +17,7 @@
       ]
     },
     {
-      "identifier": "urn:air:acme.com:server:weather",
+      "identifier": "urn:ai:acme.com:server:weather",
       "displayName": "Weather Data Node",
       "type": "application/mcp-server-card+json",
       "url": "https://api.acme.com/mcp/weather.json",
@@ -29,14 +29,14 @@
       ]
     },
     {
-      "identifier": "urn:air:acme.com:catalog:engineering",
+      "identifier": "urn:ai:acme.com:catalog:engineering",
       "displayName": "Engineering Sub-Catalog Reference",
       "type": "application/ai-catalog+json",
       "url": "https://acme.com/catalogs/engineering.json",
       "description": "Nested catalog containing CI/CD and internal deployment agents."
     },
     {
-      "identifier": "urn:air:acme.com:tool:unit-converter",
+      "identifier": "urn:ai:acme.com:tool:unit-converter",
       "displayName": "Unit Converter",
       "type": "application/mcp-server-card+json",
       "url": "https://api.acme.com/mcp/unit-converter.json"

--- a/conformance/examples/registry-server.py
+++ b/conformance/examples/registry-server.py
@@ -17,7 +17,7 @@ PORT = 9010
 # Mock catalog database seeded from spec/examples/ai-catalog.json
 MOCK_CATALOG_ENTRIES = [
   {
-    "identifier": "urn:air:acme.com:agent:assistant",
+    "identifier": "urn:ai:acme.com:agent:assistant",
     "displayName": "Corporate Assistant (A2A)",
     "type": "application/a2a-agent-card+json",
     "url": "https://api.acme.com/agents/assistant.json",
@@ -28,7 +28,7 @@ MOCK_CATALOG_ENTRIES = [
     ]
   },
   {
-    "identifier": "urn:air:acme.com:server:weather",
+    "identifier": "urn:ai:acme.com:server:weather",
     "displayName": "Weather Data Node",
     "type": "application/mcp-server-card+json",
     "url": "https://api.acme.com/mcp/weather.json",
@@ -40,14 +40,14 @@ MOCK_CATALOG_ENTRIES = [
     ]
   },
   {
-    "identifier": "urn:air:acme.com:catalog:engineering",
+    "identifier": "urn:ai:acme.com:catalog:engineering",
     "displayName": "Engineering Sub-Catalog Reference",
     "type": "application/ai-catalog+json",
     "url": "https://acme.com/catalogs/engineering.json",
     "description": "Nested catalog containing CI/CD and internal deployment agents."
   },
   {
-    "identifier": "urn:air:acme.com:tool:unit-converter",
+    "identifier": "urn:ai:acme.com:tool:unit-converter",
     "displayName": "Unit Converter",
     "type": "application/mcp-server-card+json",
     "url": "https://api.acme.com/mcp/unit-converter.json"

--- a/spec/ard.md
+++ b/spec/ard.md
@@ -79,7 +79,7 @@ A manifest file hosted at /.well-known/ai-catalog.json lists the available artif
   },
   "entries": [
     {
-      "identifier": "urn:air:acme.com:agent:assistant",
+      "identifier": "urn:ai:acme.com:agent:assistant",
       "displayName": "Corporate Assistant (A2A)",
       "type": "application/a2a-agent-card+json",
       "url": "https://api.acme.com/agents/assistant.json",
@@ -90,7 +90,7 @@ A manifest file hosted at /.well-known/ai-catalog.json lists the available artif
       ]
     },
     {
-      "identifier": "urn:air:acme.com:server:weather",
+      "identifier": "urn:ai:acme.com:server:weather",
       "displayName": "Weather Data Node",
       "type": "application/mcp-server-card+json",
       "url": "https://api.acme.com/mcp/weather.json",
@@ -102,7 +102,7 @@ A manifest file hosted at /.well-known/ai-catalog.json lists the available artif
       ]
     },
     {
-      "identifier": "urn:air:acme.com:plugin:finance-suite",
+      "identifier": "urn:ai:acme.com:plugin:finance-suite",
       "displayName": "Finance Tool Bundle",
       "type": "application/ai-catalog+json",
       "description": "A static nested bundle containing an A2A agent and its required market dataset.",
@@ -111,13 +111,13 @@ A manifest file hosted at /.well-known/ai-catalog.json lists the available artif
         "specVersion": "1.0",
         "entries": [
           {
-            "identifier": "urn:air:acme.com:finance:a2a",
+            "identifier": "urn:ai:acme.com:finance:a2a",
             "displayName": "Finance Trading Agent",
             "type": "application/a2a-agent-card+json",
             "url": "https://api.acme.com/agents/finance-trader.json"
           },
           {
-            "identifier": "urn:air:acme.com:market:2026",
+            "identifier": "urn:ai:acme.com:market:2026",
             "displayName": "Market Dataset 2026",
             "type": "application/parquet",
             "url": "https://data.acme.com/market-2026.parquet"
@@ -126,7 +126,7 @@ A manifest file hosted at /.well-known/ai-catalog.json lists the available artif
       }
     },
     {
-      "identifier": "urn:air:acme.com:registry:global",
+      "identifier": "urn:ai:acme.com:registry:global",
       "displayName": "Acme Global Agent Registry",
       "type": "application/ai-registry+json",
       "url": "https://registry.acme.com/api/v1/",
@@ -148,7 +148,7 @@ A manifest file hosted at /.well-known/ai-catalog.json lists the available artif
       }
     },
     {
-      "identifier": "urn:air:acme.com:catalog:engineering",
+      "identifier": "urn:ai:acme.com:catalog:engineering",
       "displayName": "Engineering Department Catalogs",
       "type": "application/ai-catalog+json",
       "url": "https://acme.com/catalogs/engineering.json",
@@ -164,7 +164,7 @@ Each object in the entries array MUST contain:
 
 | Field | Type | Description |
 | :---- | :---- | :---- |
-| identifier | String | Globally unique logical identifier for discovery. MUST use a domain-anchored URN namespace format (`urn:air:<publisher>:<namespace>:<agent-name>`) where `<publisher>` is a verifiable domain name. This guarantees cross-network uniqueness, nomenclature stability, and decentralized trust binding. See [§4.2.1](#421-agent-identifier-identifier-format-and-rationale) for detailed format specifications and architectural rationale. |
+| identifier | String | Globally unique logical identifier for discovery. MUST use a domain-anchored URN namespace format (`urn:ai:<publisher>:<namespace>:<agent-name>`) where `<publisher>` is a verifiable domain name. This guarantees cross-network uniqueness, nomenclature stability, and decentralized trust binding. See [§4.2.1](#421-agent-identifier-identifier-format-and-rationale) for detailed format specifications and architectural rationale. |
 | displayName | String | Human-readable name. |
 | type | String | Type of the AI artifact. |
 
@@ -193,7 +193,7 @@ Optional fields:
 The identifier field serves as the primary logical handle for an agent or capability across federated discovery networks. It MUST follow a standardized, domain-anchored URN format complying with IETF RFC 8141:
 
 ```
-urn:air:<publisher>:<namespace>:<agent-name>
+urn:ai:<publisher>:<namespace>:<agent-name>
 ```
 
 #### Format Structure
@@ -232,7 +232,7 @@ An agent hosted on Hugging Face Spaces (MCP), published in a manifest:
   "host": { "displayName": "Alice's AI Tools" },
   "entries": [
     {
-      "identifier": "urn:air:hf.co:alice-dev:weather-agent",
+      "identifier": "urn:ai:hf.co:alice-dev:weather-agent",
       "displayName": "Weather Agent",
       "type": "application/mcp-server-card+json",
       "data": {
@@ -263,7 +263,7 @@ A skill hosted on GitHub, published in a manifest:
   "host": { "displayName": "Alice's AI Tools" },
   "entries": [
     {
-      "identifier": "urn:air:github.com:alice-dev:pptx-creator",
+      "identifier": "urn:ai:github.com:alice-dev:pptx-creator",
       "displayName": "pptx-creator",
       "type": "application/ai-skill",
       "url": "https://github.com/alice-dev/pptx-creator",
@@ -281,13 +281,13 @@ Discovery via GitHub Pages (combining the above):
   "host": { "displayName": "Alice's AI Tools" },
   "entries": [
     {
-      "identifier": "urn:air:hf.co:alice-dev:weather-agent",
+      "identifier": "urn:ai:hf.co:alice-dev:weather-agent",
       "displayName": "Weather Agent",
       "type": "application/mcp-server-card+json",
       "url": "https://alice-dev.github.io/weather-agent/entry.json"
     },
     {
-      "identifier": "urn:air:github.com:alice-dev:pptx-creator",
+      "identifier": "urn:ai:github.com:alice-dev:pptx-creator",
       "displayName": "pptx-creator",
       "type": "application/ai-skill+md",
       "url": "https://github.com/alice-dev/pptx-creator"
@@ -309,7 +309,7 @@ Using trustManifest for compliance, published in a manifest.
   },
   "entries": [
     {
-      "identifier": "urn:air:acme.com:travel:concierge",
+      "identifier": "urn:ai:acme.com:travel:concierge",
       "displayName": "Travel Concierge",
       "type": "application/a2a-agent-card+json",
       "url": "https://api.acme.com/travel/concierge.json",
@@ -473,7 +473,7 @@ The response returns standard catalog entries with additional relevance scores, 
 {
   "results": [
     {
-      "identifier": "urn:air:acme.com:agent:assistant",
+      "identifier": "urn:ai:acme.com:agent:assistant",
       "displayName": "Corporate Assistant (A2A)",
       "type": "application/a2a-agent-card+json",
       "url": "https://api.acme.com/agents/assistant.json",
@@ -481,7 +481,7 @@ The response returns standard catalog entries with additional relevance scores, 
       "source": "https://registry.acme.com/api/v1/"
     },
     {
-      "identifier": "urn:air:example.com:weather-server",
+      "identifier": "urn:ai:example.com:weather-server",
       "displayName": "Global Weather Service",
       "type": "application/mcp-server-card+json",
       "url": "https://weather.example.com/mcp",
@@ -492,7 +492,7 @@ The response returns standard catalog entries with additional relevance scores, 
   ],
   "referrals": [
     {
-      "identifier": "urn:air:nlweb.ai:registry:public",
+      "identifier": "urn:ai:nlweb.ai:registry:public",
       "displayName": "Public Agent Finder",
       "type": "application/ai-registry+json",
       "url": "https://finder.nlweb.ai/search"
@@ -626,7 +626,7 @@ This gives the client full control over the federation topology without requirin
 {
   "results": [
     {
-      "identifier": "urn:air:acme.com:agent:expense",
+      "identifier": "urn:ai:acme.com:agent:expense",
       "displayName": "Corporate Expenses",
       "type": "application/a2a-agent-card+json",
       "url": "https://internal.corp/agents/expense.json",
@@ -636,13 +636,13 @@ This gives the client full control over the federation topology without requirin
   ],
   "referrals": [
     {
-      "identifier": "urn:air:nlweb.ai:registry:public",
+      "identifier": "urn:ai:nlweb.ai:registry:public",
       "displayName": "Public Agent Finder",
       "type": "application/ai-registry",
       "url": "https://finder.nlweb.ai/search"
     },
     {
-      "identifier": "urn:air:example.com:registry:travel",
+      "identifier": "urn:ai:example.com:registry:travel",
       "displayName": "Travel Agent Finder",
       "type": "application/ai-registry",
       "url": "https://travel.finder.example/search"
@@ -690,10 +690,10 @@ Logical AND is used across different parameters; OR is used within a single para
 
 Restricting the discovery identifier to this specific URN format, rather than allowing arbitrary URIs (such as https://... or spiffe://...), provides fundamental architectural benefits for federated agent discovery:
 
-1. **Nomenclature Stability (Immutable Noun vs. Mutable Location)**: Arbitrary URIs, particularly HTTP URLs, conflate the *logical identity* of a capability with its *physical network location*. If an enterprise migrates workloads across cloud providers, restructures its API gateway, or alters its deployment clusters, an HTTP URL breaks. The urn:air: identifier acts as an abstract, permanent contract (the "noun"). Physical distribution and transport bindings are decoupled into the url or data fields, allowing underlying infrastructure to evolve without breaking client discovery, indexing, or orchestration code.  
-2. **Strict Separation of Concerns**: Federated search registries require a clean, stable primary key to index capabilities efficiently across global networks. Conversely, zero-trust execution runtimes require dynamic, verifiable cryptographic tokens (SPIFFE IDs, DIDs, X.509 certificates) to authenticate workloads. Forcing a single URI to serve both roles creates an architectural bottleneck. The urn:air: format cleanly decouples the searchable discovery handle from the security principal, allowing the discovery index and the security mesh to operate independently.  
-3. **Decentralized Trust and Authority Binding**: In a globally federated open discovery network, search registries must prevent malicious actors from claiming namespaces they do not own (e.g., an untrusted publisher claiming urn:air:google.com:tax-agent). Mandating that `<publisher>` be a valid FQDN establishes an immediate, verifiable authority anchor. Registries and orchestrators programmatically extract the domain from the URN (google.com) and cross-reference it with the cryptographic claim in trustManifest.identity. If the workload cannot produce a valid cryptographic attestation (e.g., mTLS certificate or SPIFFE SVID) issued by google.com, the capability is rejected. This ensures decentralized, zero-trust verification without requiring a centralized naming committee.  
-4. **Search and Discovery Ergonomics (The @ Resolution Pattern)**: Users and LLMs require intuitive, semantic handles for capabilities (e.g., Assistant@Acme). The structured hierarchy of `urn:air:<publisher>:<namespace>:<agent-name>` allows search engines and federated registries to parse components deterministically. Registries can easily match natural language queries to the publisher domain (Acme) and the terminal short name (Assistant), enabling high-performance semantic filtering, aggregation, and conflict resolution (e.g., displaying Assistant with a verified Acme shield).  
+1. **Nomenclature Stability (Immutable Noun vs. Mutable Location)**: Arbitrary URIs, particularly HTTP URLs, conflate the *logical identity* of a capability with its *physical network location*. If an enterprise migrates workloads across cloud providers, restructures its API gateway, or alters its deployment clusters, an HTTP URL breaks. The urn:ai: identifier acts as an abstract, permanent contract (the "noun"). Physical distribution and transport bindings are decoupled into the url or data fields, allowing underlying infrastructure to evolve without breaking client discovery, indexing, or orchestration code.  
+2. **Strict Separation of Concerns**: Federated search registries require a clean, stable primary key to index capabilities efficiently across global networks. Conversely, zero-trust execution runtimes require dynamic, verifiable cryptographic tokens (SPIFFE IDs, DIDs, X.509 certificates) to authenticate workloads. Forcing a single URI to serve both roles creates an architectural bottleneck. The urn:ai: format cleanly decouples the searchable discovery handle from the security principal, allowing the discovery index and the security mesh to operate independently.  
+3. **Decentralized Trust and Authority Binding**: In a globally federated open discovery network, search registries must prevent malicious actors from claiming namespaces they do not own (e.g., an untrusted publisher claiming urn:ai:google.com:tax-agent). Mandating that `<publisher>` be a valid FQDN establishes an immediate, verifiable authority anchor. Registries and orchestrators programmatically extract the domain from the URN (google.com) and cross-reference it with the cryptographic claim in trustManifest.identity. If the workload cannot produce a valid cryptographic attestation (e.g., mTLS certificate or SPIFFE SVID) issued by google.com, the capability is rejected. This ensures decentralized, zero-trust verification without requiring a centralized naming committee.  
+4. **Search and Discovery Ergonomics (The @ Resolution Pattern)**: Users and LLMs require intuitive, semantic handles for capabilities (e.g., Assistant@Acme). The structured hierarchy of `urn:ai:<publisher>:<namespace>:<agent-name>` allows search engines and federated registries to parse components deterministically. Registries can easily match natural language queries to the publisher domain (Acme) and the terminal short name (Assistant), enabling high-performance semantic filtering, aggregation, and conflict resolution (e.g., displaying Assistant with a verified Acme shield).  
 5. **Cross-Network Uniqueness and Federation Scalability**: Domain-anchored URNs guarantee global uniqueness across disparate federated registries without requiring centralized registration databases. Because domain names are already globally unique via the DNS root, anchoring the URN to a domain eliminates collision risks when merging catalogs from multiple upstream registries in auto or referrals federation modes.
 
 ---
@@ -719,7 +719,7 @@ The JSON representation of the capability manifest hosted at `/.well-known/ai-ca
 
 * **Authoritative Schema File**: [`spec/schemas/ai-catalog.schema.json`](schemas/ai-catalog.schema.json)
 * **Key Validation Enforcements**:
-  * Pattern matching URN compliance rules for the logical `identifier` format (`^urn:air:...`).
+  * Pattern matching URN compliance rules for the logical `identifier` format (`^urn:ai:...`).
   * Strict Value-or-Reference exclusion logic (`oneOf` matching either `url` or `data`, preventing duplicate definitions).
   * Struct checking for SPIFFE/DID compliance in `trustManifest` and `attestations` objects.
 

--- a/spec/schemas/ai-catalog.schema.json
+++ b/spec/schemas/ai-catalog.schema.json
@@ -67,8 +67,8 @@
       "properties": {
         "identifier": {
           "type": "string",
-          "pattern": "^urn:air:[a-zA-Z0-9.-]+(:[a-zA-Z0-9._-]+)+$",
-          "description": "RFC 8141-compliant unique logical URN formatted as: urn:air:<publisher>:<namespace>:<agent-name>"
+          "pattern": "^urn:ai:[a-zA-Z0-9.-]+(:[a-zA-Z0-9._-]+)+$",
+          "description": "RFC 8141-compliant unique logical URN formatted as: urn:ai:<publisher>:<namespace>:<agent-name>"
         },
         "displayName": {
           "type": "string",

--- a/spec/schemas/ard.cddl
+++ b/spec/schemas/ard.cddl
@@ -20,7 +20,7 @@ host-info = {
 }
 
 catalog-entry = {
-  identifier: tstr, ; URN pattern: urn:air:<publisher>:<namespace>:<agent-name>
+  identifier: tstr, ; URN pattern: urn:ai:<publisher>:<namespace>:<agent-name>
   displayName: tstr,
   type: tstr, ; IANA Media Type (e.g. application/mcp-server-card+json)
   

--- a/spec/schemas/ard.openapi.yaml
+++ b/spec/schemas/ard.openapi.yaml
@@ -298,7 +298,7 @@ components:
         identifier:
           type: string
           description: Logical identifier of the referred registry.
-          example: "urn:air:nlweb.ai:registry:public"
+          example: "urn:ai:nlweb.ai:registry:public"
         displayName:
           type: string
           description: Name of the referred registry.

--- a/spec/urn-naming-guide.md
+++ b/spec/urn-naming-guide.md
@@ -9,7 +9,7 @@ This guide provides architectural best practices and implementation guidance for
 Every agent or capability in the discovery catalog is uniquely identified by a domain-anchored URN namespace (as defined in RFC 8141):
 
 ```text
-urn:air:<publisher>:<namespace>:<agent-name>
+urn:ai:<publisher>:<namespace>:<agent-name>
 ```
 
 The absolute foundational principle of this identifier is the separation of **logical identity** from **physical location**:
@@ -21,7 +21,7 @@ The absolute foundational principle of this identifier is the separation of **lo
 ## 2. Why `localhost` is an Anti-Pattern in URNs
 
 When running and testing agents locally, developers may be tempted to structure URNs like:
-`urn:air:localhost:agent:assistant`
+`urn:ai:localhost:agent:assistant`
 
 Using `'localhost'` as the URN publisher is not allowed for the following reasons:
 
@@ -39,8 +39,8 @@ The specification provides clear, flexible pathways for developers to construct 
 If you are building and testing an agent that will **only run locally** and will never be published to a shared or public discovery registry, you can use a **placeholder FQDN** to satisfy syntax validators:
 
 * **Recommended Placeholders** (Using RFC 2606 reserved testing domains):
-  * `urn:air:agent.localhost:<namespace>:<agent-name>` (Recommended for local sandboxes — reserved TLD mapping natively to loopback, avoiding `/etc/hosts` changes)
-  * `urn:air:example.com:<namespace>:<agent-name>` (Reserved domain for documentation and static examples)
+  * `urn:ai:agent.localhost:<namespace>:<agent-name>` (Recommended for local sandboxes — reserved TLD mapping natively to loopback, avoiding `/etc/hosts` changes)
+  * `urn:ai:example.com:<namespace>:<agent-name>` (Reserved domain for documentation and static examples)
 
 #### Example Manifest (`ai-catalog.json`):
 ```json
@@ -51,7 +51,7 @@ If you are building and testing an agent that will **only run locally** and will
   },
   "entries": [
     {
-      "identifier": "urn:air:agent.localhost:weather:telemetry",
+      "identifier": "urn:ai:agent.localhost:weather:telemetry",
       "displayName": "Local Weather Node",
       "type": "application/mcp-server-card+json",
       "url": "http://localhost:8080/mcp",
@@ -71,15 +71,15 @@ Since domain names are already globally unique via the DNS root, anchoring your 
 
 1. **Alternative Code Hosts / Package Registries**:
    If you distribute via other code hosting or packaging platforms, use their domain combined with your user namespace:
-   * GitLab: `urn:air:gitlab.com:your-username:my-agent`
-   * npm: `urn:air:npmjs.com:your-username:my-agent`
-   * PyPI: `urn:air:pypi.org:your-username:my-agent`
+   * GitLab: `urn:ai:gitlab.com:your-username:my-agent`
+   * npm: `urn:ai:npmjs.com:your-username:my-agent`
+   * PyPI: `urn:ai:pypi.org:your-username:my-agent`
 
 2. **Free Subdomains**:
    If you host a portfolio, documentation, or personal page using a free hosting provider, use your allocated subdomain:
-   * Vercel: `urn:air:your-app.vercel.app:my-agent`
-   * Netlify: `urn:air:your-site.netlify.app:my-agent`
-   * GitHub Pages: `urn:air:your-username.github.io:my-agent`
+   * Vercel: `urn:ai:your-app.vercel.app:my-agent`
+   * Netlify: `urn:ai:your-site.netlify.app:my-agent`
+   * GitHub Pages: `urn:ai:your-username.github.io:my-agent`
 ---
 
 ### Scenario C: Enterprise Developers or Developers with a Verified Domain
@@ -88,7 +88,7 @@ For developers inside an enterprise or those who own a custom domain (e.g., `acm
 This ensures that the URN remains completely identical between their local development, staging, and production catalogs, avoiding the need to rewrite downstream orchestration rules or client references.
 
 * **Guidance**:
-  * **URN (Identity)**: Use the real FQDN (e.g., `urn:air:acme.com:finance:tax-agent`).
+  * **URN (Identity)**: Use the real FQDN (e.g., `urn:ai:acme.com:finance:tax-agent`).
   * **Physical Endpoint**: Point to `localhost` in the local development manifest, and to the production gateway or API host in the production manifest.
 
 #### Local Manifest Example (`ai-catalog-local.json`):
@@ -101,7 +101,7 @@ This ensures that the URN remains completely identical between their local devel
   },
   "entries": [
     {
-      "identifier": "urn:air:acme.com:finance:tax-agent",
+      "identifier": "urn:ai:acme.com:finance:tax-agent",
       "displayName": "Corporate Tax Assistant",
       "type": "application/a2a-agent-card+json",
       "url": "http://localhost:8000/agents/tax-assistant",
@@ -121,7 +121,7 @@ This ensures that the URN remains completely identical between their local devel
   },
   "entries": [
     {
-      "identifier": "urn:air:acme.com:finance:tax-agent",
+      "identifier": "urn:ai:acme.com:finance:tax-agent",
       "displayName": "Corporate Tax Assistant",
       "type": "application/a2a-agent-card+json",
       "url": "https://api.acme.com/finance/tax-assistant",
@@ -148,6 +148,6 @@ This ensures that the URN remains completely identical between their local devel
 
 | Deployment Context | Publisher FQDN | URN Example | Physical URL (Endpoint) | Trust Manifest Capability |
 | :--- | :--- | :--- | :--- | :--- |
-| **Enterprise Production** | Fully verified corporate domain | `urn:air:aws.amazon.com:finance:trader` | `https://api.aws.amazon.com/agents/trader` | Fully supported (SPIFFE/mTLS/DID) |
-| **Solo Developer (Public)** | Registered user namespace / free subdomain | `urn:air:gitlab.com:johndoe:weather-tool` | `https://gitlab.com/johndoe/weather-tool` | Basic signatures / web DID |
-| **Local / Private Dev** | Non-resolvable placeholder domain | `urn:air:agent.localhost:testing:analyzer` | `http://localhost:8080/analyzer` | None (Syntax verification only) |
+| **Enterprise Production** | Fully verified corporate domain | `urn:ai:aws.amazon.com:finance:trader` | `https://api.aws.amazon.com/agents/trader` | Fully supported (SPIFFE/mTLS/DID) |
+| **Solo Developer (Public)** | Registered user namespace / free subdomain | `urn:ai:gitlab.com:johndoe:weather-tool` | `https://gitlab.com/johndoe/weather-tool` | Basic signatures / web DID |
+| **Local / Private Dev** | Non-resolvable placeholder domain | `urn:ai:agent.localhost:testing:analyzer` | `http://localhost:8080/analyzer` | None (Syntax verification only) |


### PR DESCRIPTION
The official spec is `urn:ai:` for the namespace. The examples here often use `urn:air:`

Or at least, I assume it is `urn:ai` from https://agenticresourcediscovery.org/how_to_publish/

and that the hugging face discovery plugin errors out when I use `air` instead of `ai