### PR TITLE
docs(conformance): fix stale example paths after examples/ reorg

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -40,7 +40,7 @@ Validates a local file or a remote live HTTP URL pointing to an `ai-catalog.json
 
 ```bash
 # Validate a local catalog manifest file
-./bin/conformance-test manifest examples/ai-catalog.json
+./bin/conformance-test manifest examples/basic/ai-catalog.json
 
 # Validate a remote well-known catalog manifest hosted on a web server
 ./bin/conformance-test manifest https://example.com/.well-known/ai-catalog.json

--- a/conformance/examples/basic/registry-server.py
+++ b/conformance/examples/basic/registry-server.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse, parse_qs
 
 PORT = 9010
 
-# Mock catalog database seeded from spec/examples/ai-catalog.json
+# Mock catalog database seeded from ./ai-catalog.json
 MOCK_CATALOG_ENTRIES = [
   {
     "identifier": "urn:air:acme.com:agent:assistant",


### PR DESCRIPTION
> Hi! 👋 
> 
> I'm Ben, an engineer on the Agent Discovery team at Zapier. 
> 
> We’re excited to see how this space evolves and will be following this repo closely. Thanks for all the work you’ve put into it so far! If you’re ever interested in chatting or collaborating, feel free to reach out.

## Summary

Two references to the mock catalog manifest were left pointing at old locations after the `c60a002` reorg moved it into `examples/basic/`:

- **`conformance/README.md`** — the documented manual-validation command (`./bin/conformance-test manifest examples/ai-catalog.json`) now 404s; updated to `examples/basic/ai-catalog.json` so copy/paste works.
- **`conformance/examples/basic/registry-server.py`** — comment claimed the mock data was seeded from `spec/examples/ai-catalog.json`, a path that has not existed since the earlier reorg in `5c191fb`. Repointed to `./ai-catalog.json` (its real, current sibling).

No spec or behavioral changes — docs/comment only.

## Test plan

- [x] `./bin/conformance-test manifest examples/basic/ai-catalog.json` — passes (was previously a `Local file does not exist` failure with the README's stale path)
- [x] `./bin/run-conformance-demo` — full end-to-end demo passes (`ALL CONFORMANCE CHECKS PASSED`)