### PR TITLE
Add local-business storefront catalog example (SMB as an agentic resource)

### DIFF
--- a/conformance/examples/local-business/local-business-catalog.json
+++ b/conformance/examples/local-business/local-business-catalog.json
@@ -1,0 +1,97 @@
+{
+  "specVersion": "1.0",
+  "host": {
+    "displayName": "Bob's Plumbing & Drain",
+    "identifier": "did:web:bobs-plumbing.example",
+    "documentationUrl": "https://bobs-plumbing.example"
+  },
+  "entries": [
+    {
+      "identifier": "urn:air:bobs-plumbing.example:agent:assistant",
+      "displayName": "Bob's Plumbing & Drain AI Assistant",
+      "type": "application/a2a-agent-card+json",
+      "mediaType": "application/a2a-agent-card+json",
+      "url": "https://bobs-plumbing.example/.well-known/agent-card.json",
+      "description": "Conversational A2A agent for a family-owned plumbing company in Minneapolis, MN. Answers service questions, checks technician availability, and books appointments over the A2A protocol.",
+      "tags": ["local-business", "plumbing", "home-services"],
+      "representativeQueries": [
+        "find an emergency plumber in Minneapolis",
+        "talk to Bob's Plumbing about a water heater replacement",
+        "book a drain cleaning appointment for tomorrow morning",
+        "connect me to the AI assistant for Bob's Plumbing & Drain"
+      ],
+      "metadata": {
+        "schemaOrgType": "Plumber",
+        "address": "4519 Excelsior Blvd, Minneapolis, MN 55416, US",
+        "telephone": "+1-612-555-0148",
+        "areaServed": "Minneapolis; St. Paul; Bloomington",
+        "openingHours": "Mo-Fr 07:00-18:00; Sa 08:00-14:00"
+      },
+      "trustManifest": {
+        "identity": "did:web:bobs-plumbing.example",
+        "identityType": "did",
+        "attestations": [
+          {
+            "type": "State-Contractor-License",
+            "uri": "https://license-lookup.example/contractors/bobs-plumbing",
+            "mediaType": "text/html"
+          },
+          {
+            "type": "Liability-Insurance-Certificate",
+            "uri": "https://bobs-plumbing.example/trust/insurance-certificate.pdf",
+            "mediaType": "application/pdf"
+          }
+        ]
+      }
+    },
+    {
+      "identifier": "urn:air:bobs-plumbing.example:mcp:storefront",
+      "displayName": "Bob's Plumbing & Drain Storefront Tools",
+      "type": "application/mcp-server-card+json",
+      "mediaType": "application/mcp-server-card+json",
+      "description": "MCP server card for the business storefront: structured tools to check technician availability, request a quote, and look up hours and service area. Embedded inline via the data field (value-or-reference, ARD 3.4).",
+      "tags": ["local-business", "booking", "quotes"],
+      "capabilities": ["check_availability", "request_quote", "get_business_hours"],
+      "representativeQueries": [
+        "is a plumber available this afternoon near Minneapolis",
+        "get a quote for replacing a sump pump",
+        "what are the business hours for Bob's Plumbing & Drain"
+      ],
+      "data": {
+        "name": "bobs-plumbing-storefront",
+        "description": "Storefront MCP server for Bob's Plumbing & Drain (Minneapolis, MN). Availability checks, quote requests, and business-hours lookups for plumbing and drain services.",
+        "tools": [
+          {
+            "name": "check_availability",
+            "description": "Check whether a technician is available for a given service and time window.",
+            "inputSchema": {
+              "type": "object",
+              "properties": {
+                "service": { "type": "string", "description": "Service requested, e.g. 'drain cleaning'" },
+                "requested_window": { "type": "string", "description": "Requested time window (ISO 8601 interval)" }
+              },
+              "required": ["service"]
+            }
+          },
+          {
+            "name": "request_quote",
+            "description": "Request a quote for a plumbing job. Returns a ticket ID that a human dispatcher follows up on.",
+            "inputSchema": {
+              "type": "object",
+              "properties": {
+                "job_description": { "type": "string", "description": "Plain-language description of the job" },
+                "callback_phone": { "type": "string", "description": "Customer callback number" }
+              },
+              "required": ["job_description"]
+            }
+          },
+          {
+            "name": "get_business_hours",
+            "description": "Current business hours, including holiday exceptions.",
+            "inputSchema": { "type": "object", "properties": {} }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds `conformance/examples/local-business/local-business-catalog.json` — a worked
`ai-catalog.json` for a fictional small local business (a plumbing company at the
RFC 2606 domain `bobs-plumbing.example`), following the pattern established by the
FDA Drug NDC Directory example (#46).

## Why a local-business example

The existing examples cover an enterprise API (FDA, #46) and generic/basic
catalogs. The long tail of agentic resources is neither: it's the millions of
small businesses whose "agent surface" is a conversational assistant plus a
handful of storefront tools (availability, quotes, hours). This example shows
what publishing that surface looks like end to end:

- **One business, two artifact types** — an `application/a2a-agent-card+json`
  entry (conversational agent, referenced via `url` at the registered
  `/.well-known/agent-card.json` path) and an `application/mcp-server-card+json`
  entry (structured storefront tools, embedded via `data`) — exercising both
  halves of strict value-or-reference (§3.4).
- **SMB-grade trust** — a `trustManifest` whose attestations are the local
  equivalents of enterprise compliance: a state contractor license lookup and a
  liability-insurance certificate (attestation `type` treated as an open set,
  as in #46).
- **Schema.org-vocabulary metadata** (§4.5) — `schemaOrgType`, address,
  telephone, service area, opening hours — the filter dimensions a registry
  needs for "find me a plumber open now near Minneapolis"-class queries.
- **RFC 2606 naming** — `bobs-plumbing.example` per ADR-0003.

## Conformance

Passes `conformance/bin/conformance-test manifest` with strict JSON Schema
validation enabled (0 errors, 0 warnings): URN format, value-or-reference, and
representativeQueries sizing all green.

## Note on `type` + `mediaType`

Each entry emits the IANA media type under **both** `type` and `mediaType`,
with identical values. The base ai-catalog spec and this spec's examples have
not fully converged on one property name (see #43 and #27, both of which emit
the pair for cross-spec compatibility). The schema tolerates the extra
property, and publishers like us are already dual-emitting in production so
consumers of either spelling can parse the catalogs. Happy to collapse this
example to a single field the moment the WG settles the canonical name — which
would be great to see happen before the 1.0 media-type freeze.

